### PR TITLE
Rename ecp-proxy-init to ecp-get-cert

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ test_script:
   # run --help on scripts for sanity
   - python -m coverage run --append -m ciecplib.tool.ecp_cookie_init --help
   - python -m coverage run --append -m ciecplib.tool.ecp_curl --help
-  - python -m coverage run --append -m ciecplib.tool.ecp_proxy_init --help
+  - python -m coverage run --append -m ciecplib.tool.ecp_get_cert --help
 after_test:
   - python -m coverage report
   - python -m pip install codecov

--- a/ciecplib.spec
+++ b/ciecplib.spec
@@ -47,7 +47,7 @@ Summary: Command line utilities for SAML ECP authentication
 Requires: python2-%{name} = %{version}
 %description -n ciecp-utils
 Command line utilities for SAML ECP authentication, including
-ecp-cookit-init, ecp-proxy-init, and ecp-curl
+ecp-cookit-init, ecp-get-cert, and ecp-curl
 (an ECP-aware curl alternative).
 
 # -- build ------------------

--- a/ciecplib/tool/ecp_get_cert.py
+++ b/ciecplib/tool/ecp_get_cert.py
@@ -20,11 +20,11 @@ r"""Create an X.509 certificate using ECP authentication.
 
 There are two usages:
 
-1) ``ecp-proxy-init albert.einstein``
+1) ``ecp-get-cert albert.einstein``
 
 to authenticate with a password prompt, or
 
-2) ``ecp-proxy-init -k``
+2) ``ecp-get-cert -k``
 
 to reuse an existing kerberos (``kinit``) credential.
 By default the credential file is created and stored in a location

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,11 +1,10 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: ciecplib
 Upstream-Contact: Duncan Macleod <duncan.macleod@ligo.org>
 Source: https://git.ligo.org/duncanmmacleod/ciecplib
 
 Files: *
 Copyright: 2019 Duncan Macleod <duncan.macleod@ligo.org>
-License: GPL-3+
-
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/docs/ecp-get-cert.rst
+++ b/docs/ecp-get-cert.rst
@@ -1,0 +1,6 @@
+ecp-get-cert
+============
+
+.. argparse::
+   :ref: ciecplib.tool.ecp_get_cert.create_parser
+   :prog: ecp-get-cert

--- a/docs/ecp-proxy-init.rst
+++ b/docs/ecp-proxy-init.rst
@@ -1,6 +1,0 @@
-ecp-proxy-init
-===============
-
-.. argparse::
-   :ref: ciecplib.tool.ecp_proxy_init.create_parser
-   :prog: ecp-proxy-init

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ Command-line scripts
 
    ecp-cookie-init
    ecp-curl
-   ecp-proxy-init
+   ecp-get-cert
 
 |
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "console_scripts": [
             "ecp-cookie-init=ciecplib.tool.ecp_cookie_init:main",
             "ecp-curl=ciecplib.tool.ecp_curl:main",
-            "ecp-proxy-init=ciecplib.tool.ecp_proxy_init:main",
+            "ecp-get-cert=ciecplib.tool.ecp_get_cert:main",
         ],
     },
     # dependencies


### PR DESCRIPTION
This PR renames the `ecp-proxy-init` script to `ecp-get-cert` to better describe what it does.