### PR TITLE
Fix bugs in utils._endpoint_url func

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ aliases:
               python${PYXY}-pytest-cov \
               $([ "${PYXY}" -eq 2 ] && echo "python2-mock") \
           ;
-          python${PYTHON_VERSION} -m pip install "pytest~=3.0" "more-itertools < 6.0a0"
+          python${PYTHON_VERSION} -m pip install "pytest~=3.0" "more-itertools < 6.0a0" "zipp!=2.0.0"
 
   - &test
       run:

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,3 @@
+scanner:
+  diff_only: True
+  linter: flake8

--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -74,6 +74,7 @@ def test_get_idp_urls_error(_, inst):
 
 @pytest.mark.parametrize("url, result", [
     ("login.ligo.org", "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
+    ("https://login.ligo.org", "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
     ("login.ligo.org/test", "https://login.ligo.org/test"),
     ("https://login.ligo.org/idp/profile/SAML2/SOAP/ECP",
      "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),

--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -73,9 +73,12 @@ def test_get_idp_urls_error(_, inst):
 
 
 @pytest.mark.parametrize("url, result", [
-    ("login.ligo.org", "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
-    ("https://login.ligo.org", "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
-    ("login.ligo.org/test", "https://login.ligo.org/test"),
+    ("login.ligo.org",
+     "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
+    ("https://login.ligo.org",
+     "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
+    ("login.ligo.org/test",
+     "https://login.ligo.org/test"),
     ("https://login.ligo.org/idp/profile/SAML2/SOAP/ECP",
      "https://login.ligo.org/idp/profile/SAML2/SOAP/ECP"),
 ])

--- a/ciecplib/utils.py
+++ b/ciecplib/utils.py
@@ -122,10 +122,11 @@ def get_idp_urls(institution, url=DEFAULT_IDPLIST_URL):
 
 
 def _endpoint_url(url):
-    if "/" not in url:
-        url = "https://{0}/idp/profile/SAML2/SOAP/ECP".format(url)
-    if not urlparse(url).scheme:
+    parsed = urlparse(url)
+    if not parsed.scheme:
         url = "https://{0}".format(url)
+    if not urlparse(url).path:
+        return "{0}/idp/profile/SAML2/SOAP/ECP".format(url)
     return url
 
 


### PR DESCRIPTION
This PR fixes an issue with the `ciecplib.utils._endpoint_url` function whereby it couldn't handle URLs with a scheme, but no path. A test to cover regression has also been added.