### PR TITLE
Add unit tests for cli

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ build_script:
   - python -m pip install .
 test_script:
   # run automated tests
-  - python -m pytest --pyargs ciecplib.tests --cov ciecplib --cov-report "" --junitxml=junit.xml
+  - python -m pytest --pyargs ciecplib --cov ciecplib --cov-report "" --junitxml=junit.xml
   # run --help on scripts for sanity
   - python -m coverage run --append -m ciecplib.tool.ecp_cookie_init --help
   - python -m coverage run --append -m ciecplib.tool.ecp_curl --help

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ aliases:
           mkdir -pv tests;
           pushd tests;
           python${PYTHON_VERSION} -m pytest \
-              --pyargs ciecplib.tests \
+              --pyargs ciecplib \
               --cov ciecplib \
               --junitxml junit.xml \
           ;

--- a/ciecplib/tool/tests/__init__.py
+++ b/ciecplib/tool/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for ciecplib
+"""
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -20,6 +20,7 @@
 """
 
 import argparse
+import sys
 try:
     from urllib.error import URLError
 except ImportError:  # python < 3
@@ -51,7 +52,11 @@ def test_argument_parser(capsys):
     # check that the version gets parsed
     with pytest.raises(SystemExit):
         parser.parse_args(["--version"])
-    assert capsys.readouterr().out.strip() == ciecplib_version
+    if sys.version_info[0] < 3:
+        # for python2 --version goes to stderr
+        assert capsys.readouterr().err.strip() == ciecplib_version
+    else:
+        assert capsys.readouterr().out.strip() == ciecplib_version
 
 
 def test_list_idps_action(capsys):

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`ciecplib.utils`
+"""
+
+import argparse
+try:
+    from urllib.error import URLError
+except ImportError:  # python < 3
+    from urllib2 import URLError
+
+import pytest
+
+from ... import __version__ as ciecplib_version
+from .. import utils as tools_utils
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def test_help_formatter():
+    parser = argparse.ArgumentParser(
+        formatter_class=tools_utils.HelpFormatter,
+    )
+    parser.add_argument("test")
+    help = parser.format_help()
+    assert "Usage: " in help
+
+
+def test_argument_parser(capsys):
+    parser = tools_utils.ArgumentParser()
+
+    # check that HelpFormatter is in place
+    assert parser.formatter_class is tools_utils.HelpFormatter
+
+    # check that the version gets parsed
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--version"])
+    assert capsys.readouterr().out.strip() == ciecplib_version
+
+
+def test_list_idps_action(capsys):
+    parser = tools_utils.ArgumentParser()
+    with pytest.raises(SystemExit):
+        try:
+            parser.parse_args(["--list-idps"])
+        except URLError as exc:
+            pytest.skip(str(exc))
+    stdout = capsys.readouterr().out
+    assert "'Cardiff University'" in stdout

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -54,9 +54,9 @@ def test_argument_parser(capsys):
         parser.parse_args(["--version"])
     if sys.version_info[0] < 3:
         # for python2 --version goes to stderr
-        assert capsys.readouterr().err.strip() == ciecplib_version
+        assert capsys.readouterr()[1].strip() == ciecplib_version
     else:
-        assert capsys.readouterr().out.strip() == ciecplib_version
+        assert capsys.readouterr()[0].strip() == ciecplib_version
 
 
 def test_list_idps_action(capsys):
@@ -66,5 +66,5 @@ def test_list_idps_action(capsys):
             parser.parse_args(["--list-idps"])
         except URLError as exc:
             pytest.skip(str(exc))
-    stdout = capsys.readouterr().out
+    stdout = capsys.readouterr()[0]
     assert "'Cardiff University'" in stdout


### PR DESCRIPTION
This PR adds a minimal unit test framework for the `ciecplib.tool` submodule that supports the command-line interfaces.