### PR TITLE
Add new command line tool ecp-cert-info

### DIFF
--- a/ciecplib.spec
+++ b/ciecplib.spec
@@ -56,7 +56,7 @@ Summary: Command line utilities for SAML ECP authentication
 Requires: python2-%{name} = %{version}-%{release}
 %description -n ciecp-utils
 Command line utilities for SAML ECP authentication, including
-ecp-cookit-init, ecp-get-cert, and ecp-curl
+ecp-cert-info, ecp-cookit-init, ecp-get-cert, and ecp-curl
 (an ECP-aware curl alternative).
 
 # -- build ------------------
@@ -81,6 +81,10 @@ sed -i "s/pykerberos/kerberos/g" setup.py
 # make man pages
 mkdir -vp %{buildroot}%{_mandir}/man1
 export PYTHONPATH="%{buildroot}%{python2_sitelib}"
+argparse-manpage \
+    --author "%{author}" --author-email "%{email}" \
+    --function create_parser --project-name %{name} --url %{url} \
+    --module ciecplib.tool.ecp_cert_info > %{buildroot}%{_mandir}/man1/ecp-cert-info.1
 argparse-manpage \
     --author "%{author}" --author-email "%{email}" \
     --function create_parser --project-name %{name} --url %{url} \

--- a/ciecplib/tool/ecp_cert_info.py
+++ b/ciecplib/tool/ecp_cert_info.py
@@ -22,8 +22,6 @@ r"""Print information about an existing X.509 credential.
 
 from __future__ import print_function
 
-import argparse
-
 from ..x509 import (
     get_x509_proxy_path,
     load_cert,

--- a/ciecplib/tool/ecp_cert_info.py
+++ b/ciecplib/tool/ecp_cert_info.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+r"""Print information about an existing X.509 credential.
+
+"""  # noqa: E501
+
+from __future__ import print_function
+
+import argparse
+
+from ..x509 import (
+    get_x509_proxy_path,
+    load_cert,
+    print_cert_info,
+)
+from .utils import (
+    ArgumentParser,
+)
+
+EPILOG = r"""
+Environment:
+
+X509_USER_PROXY:
+    the default path for the credential file
+"""
+
+MANPAGE = [
+    {'heading': 'environment',
+     'content': """
+.TP
+.B "X509_USER_PROXY"
+The default path for the credential file """,
+     },
+]
+
+
+def create_parser():
+    """Create a command-line argument parser
+
+    Returns
+    -------
+    parser : `argparse.ArgumentParser`
+    """
+    parser = ArgumentParser(
+        description=__doc__,
+        epilog=EPILOG,
+        manpage=MANPAGE,
+        prog="ecp-cert-info",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        default=get_x509_proxy_path(),
+        help="certificate file to create/reuse/destroy",
+    )
+    return parser
+
+
+def parse_args(parser):
+    """Parse and validate the command-line arguments
+
+    Returns
+    -------
+    args : `argparse.Namespace`
+    """
+    return parser.parse_args()
+
+
+def main():
+    parser = create_parser()
+    args = parse_args(parser)
+    print_cert_info(load_cert(args.file), path=args.file)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ecp-cert-info.rst
+++ b/docs/ecp-cert-info.rst
@@ -1,0 +1,6 @@
+ecp-cert-info
+=============
+
+.. argparse::
+   :ref: ciecplib.tool.ecp_cert_info.create_parser
+   :prog: ecp-cert-info

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ Command-line scripts
 .. toctree::
    :maxdepth: 1
 
+   ecp-cert-info
    ecp-cookie-init
    ecp-curl
    ecp-get-cert

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
     packages=find_packages(),
     entry_points={
         "console_scripts": [
+            "ecp-cert-info=ciecplib.tool.ecp_cert_info:main",
             "ecp-cookie-init=ciecplib.tool.ecp_cookie_init:main",
             "ecp-curl=ciecplib.tool.ecp_curl:main",
             "ecp-get-cert=ciecplib.tool.ecp_get_cert:main",


### PR DESCRIPTION
This PR adds a new command-line tool `ecp-cert-info`, which just prints the information from an existing certificate.