### PR TITLE
Use build_manpages inside setup.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,17 +72,17 @@ aliases:
       run:
         name: Install
         command: |
-          # for python3, install everything (since ciecp-utils needs py2)
-          if [[ "${PYTHON_VERSION:0:1}" -eq 3 ]]; then
+          # for python2, install everything (since ciecp-utils needs py3)
+          if [[ "${PYTHON_VERSION:0:1}" -eq 2 ]]; then
               dpkg --install python*-ciecplib*.deb ciecp-utils*.deb || { \
                   apt-get -y -f install;
                   dpkg --install python*-ciecplib*.deb ciecp-utils*.deb;
               };
-          # otherwise just install the py2 version, since python3 doesn't work
+          # otherwise just install the py3 version
           else
-              dpkg --install python-ciecplib*.deb ciecp-utils*.deb || { \
+              dpkg --install python3-ciecplib*.deb ciecp-utils*.deb || { \
                   apt-get -y -f install;
-                  dpkg --install python-ciecplib*.deb ciecp-utils*.deb;
+                  dpkg --install python3-ciecplib*.deb ciecp-utils*.deb;
               };
           fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ aliases:
               python${PYXY}-pytest-cov \
               $([ "${PYXY}" -eq 2 ] && echo "python2-mock") \
           ;
-          python${PYTHON_VERSION} -m pip install "pytest~=3.0" "more-itertools < 6.0a0" "zipp!=2.0.0"
+          python${PYTHON_VERSION} -m pip install "pytest~=3.0" "more-itertools < 6.0a0"
 
   - &test
       run:
@@ -157,7 +157,7 @@ aliases:
         command: |
           set -x;
           # install test requirements
-          python${PYTHON_VERSION} -m pip install "pytest" "pytest-cov" "mock ; python_version < '3'"
+          python${PYTHON_VERSION} -m pip install "pytest" "pytest-cov" "mock ; python_version < '3'" "zipp<2.0.0"
           # run test suite
           mkdir -pv tests;
           pushd tests;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,9 +337,6 @@ workflows:
       - centos:7:2.7:
           requires:
             - sdist
-      - debian:stretch:2.7:
-          requires:
-            - sdist
       - debian:buster:2.7:
           requires:
             - sdist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,13 +271,6 @@ jobs:
       - *store_test_results
       - *store_test_artifacts
 
-  debian:stretch:2.7:
-    <<: *debian
-    docker:
-      - image: debian:stretch
-    environment:
-      PYTHON_VERSION: "2.7"
-
   debian:buster:2.7:
     <<: *debian
     docker:

--- a/ciecplib.spec
+++ b/ciecplib.spec
@@ -78,26 +78,6 @@ sed -i "s/pykerberos/kerberos/g" setup.py
 %install
 %py2_install
 
-# make man pages
-mkdir -vp %{buildroot}%{_mandir}/man1
-export PYTHONPATH="%{buildroot}%{python2_sitelib}"
-argparse-manpage \
-    --author "%{author}" --author-email "%{email}" \
-    --function create_parser --project-name %{name} --url %{url} \
-    --module ciecplib.tool.ecp_cert_info > %{buildroot}%{_mandir}/man1/ecp-cert-info.1
-argparse-manpage \
-    --author "%{author}" --author-email "%{email}" \
-    --function create_parser --project-name %{name} --url %{url} \
-    --module ciecplib.tool.ecp_cookie_init > %{buildroot}%{_mandir}/man1/ecp-cookie-init.1
-argparse-manpage \
-    --author "%{author}" --author-email "%{email}" \
-    --function create_parser --project-name %{name} --url %{url} \
-    --module ciecplib.tool.ecp_curl > %{buildroot}%{_mandir}/man1/ecp-curl.1
-argparse-manpage \
-    --author "%{author}" --author-email "%{email}" \
-    --function create_parser --project-name %{name} --url %{url} \
-    --module ciecplib.tool.ecp_get_cert > %{buildroot}%{_mandir}/man1/ecp-cet-cert.1
-
 %clean
 rm -rf $RPM_BUILD_ROOT
 

--- a/debian/control
+++ b/debian/control
@@ -8,25 +8,31 @@ Standards-Version: 4.2.1
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4
 Homepage: https://github.com/duncanmmacleod/ciecplib
-Build-Depends: debhelper (>= 9),
-               dh-python,
-               help2man,
-               python-all,
-               python-setuptools,
-               python3-all,
-               python3-argparse-manpage,
-               python3-setuptools
+Build-Depends:
+ debhelper (>= 9),
+ dh-python,
+ help2man,
+ python-all,
+ python-setuptools,
+ python3-all,
+ python3-argparse-manpage,
+ python3-kerberos,
+ python3-lxml,
+ python3-m2crypto,
+ python3-openssl,
+ python3-setuptools,
 
 # -- python-ciecplib ----------------------------------------------------------
 
 Package: python-ciecplib
 Architecture: all
-Depends: ${misc:Depends},
-         ${python:Depends},
-         python-kerberos,
-         python-lxml,
-         python-m2crypto,
-         python-openssl
+Depends:
+ ${misc:Depends},
+ ${python:Depends},
+ python-kerberos,
+ python-lxml,
+ python-m2crypto,
+ python-openssl,
 Description: A python client for SAML ECP authentication
 
 # -- python3-ciecplib ---------------------------------------------------------
@@ -34,19 +40,21 @@ Description: A python client for SAML ECP authentication
 
 Package: python3-ciecplib
 Architecture: all
-Depends: ${misc:Depends},
-         ${python3:Depends},
-         python3-kerberos,
-         python3-lxml,
-         python3-m2crypto,
-         python3-openssl
+Depends:
+ ${misc:Depends},
+ ${python3:Depends},
+ python3-kerberos,
+ python3-lxml,
+ python3-m2crypto,
+ python3-openssl,
 Description: A python client for SAML ECP authentication
 
 # -- ciecp-utils --------------------------------------------------------------
 
 Package: ciecp-utils
 Architecture: all
-Depends: ${misc:Depends},
-         ${python3:Depends},
-         python3-ciecplib
+Depends:
+ ${misc:Depends},
+ ${python3:Depends},
+ python3-ciecplib,
 Description: Command-line utlities for SAML ECP authentication

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends: debhelper (>= 9),
                python-all,
                python-setuptools,
                python3-all,
+               python3-argparse-manpage,
                python3-setuptools
 
 # -- python-ciecplib ----------------------------------------------------------
@@ -34,7 +35,7 @@ Description: A python client for SAML ECP authentication
 Package: python3-ciecplib
 Architecture: all
 Depends: ${misc:Depends},
-         ${python:Depends},
+         ${python3:Depends},
          python3-kerberos,
          python3-lxml,
          python3-m2crypto,
@@ -46,6 +47,6 @@ Description: A python client for SAML ECP authentication
 Package: ciecp-utils
 Architecture: all
 Depends: ${misc:Depends},
-         ${python:Depends},
-         python-ciecplib
+         ${python3:Depends},
+         python3-ciecplib
 Description: Command-line utlities for SAML ECP authentication

--- a/debian/rules
+++ b/debian/rules
@@ -4,9 +4,9 @@ include /usr/share/dpkg/pkg-info.mk
 
 export PYBUILD_DISABLE = test
 
-# redirect Python 3 entry points to bogus path
-export PYBUILD_INSTALL_ARGS_python3 = --install-scripts=/ignore
-export PYBUILD_AFTER_INSTALL_python3 = rm -rf {destdir}/ignore
+# redirect Python 2 entry points to bogus path
+export PYBUILD_INSTALL_ARGS_python2 = --install-scripts=/ignore
+export PYBUILD_AFTER_INSTALL_python2 = rm -rf {destdir}/ignore
 
 %:
 	dh $@ --with python2,python3 --buildsystem=pybuild

--- a/debian/rules
+++ b/debian/rules
@@ -4,20 +4,6 @@ include /usr/share/dpkg/pkg-info.mk
 
 export PYBUILD_DISABLE = test
 
-# build man pages
-export PYBUILD_AFTER_INSTALL := \
-	echo 'Automatically generating man pages with help2man' && \
-	mkdir -p {destdir}/usr/share/man/man1 && \
-	ls {destdir}/usr/bin | env PYTHONPATH={destdir}{install_dir} \
-	xargs --verbose -I @ \
-	help2man \
-		--source $(DEB_SOURCE) \
-		--version-string $(DEB_VERSION_UPSTREAM) \
-		--no-info \
-		--no-discard-stderr \
-		{destdir}/usr/bin/@ \
-		-o {destdir}/usr/share/man/man1/@.1
-
 # redirect Python 3 entry points to bogus path
 export PYBUILD_INSTALL_ARGS_python3 = --install-scripts=/ignore
 export PYBUILD_AFTER_INSTALL_python3 = rm -rf {destdir}/ignore

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,13 @@ license_file = LICENSE
 [bdist_wheel]
 universal = 1
 
+[build_manpages]
+manpages =
+	man/ecp-cert-info.1:function=create_parser:module=ciecplib.tool.ecp_cert_info
+	man/ecp-cookie-init.1:function=create_parser:module=ciecplib.tool.ecp_cookie_init
+	man/ecp-curl.1:function=create_parser:module=ciecplib.tool.ecp_curl
+	man/ecp-get-cert.1:function=create_parser:module=ciecplib.tool.ecp_get_cert
+
 ; -- tools
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,26 @@ import os.path
 import re
 
 from setuptools import (find_packages, setup)
+from setuptools.command.build_py import build_py
+from setuptools.command.install import install
+
+try:
+    from build_manpages.build_manpages import (
+        build_manpages,
+        get_build_py_cmd,
+        get_install_cmd,
+    )
+except ImportError:  # can't build manpages, that's ok
+    cmdclass = {
+        "build_py": build_py,
+        "install": install,
+    }
+else:
+    cmdclass = {
+        "build_manpages": build_manpages,
+        "build_py": get_build_py_cmd(build_py),
+        "install": get_install_cmd(install),
+    }
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -82,7 +102,7 @@ setup(
     project_urls={
         "Bug Tracker": "https://github.com/duncanmmacleod/ciecplib/issues",
         "Documentation": "https://ciecplib.readthedocs.io/",
-        "Source Code": "https://github.com/gwpy/gwpy",
+        "Source Code": "https://github.com/duncanmmacleod/ciecplib/",
     },
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -108,6 +128,7 @@ setup(
         ],
     },
     # dependencies
+    cmdclass=cmdclass,
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
This PR modifies `setup.py` to use `build_manpages` to overload setuptools commands to build the manuals automatically. This is a protected import, so if the module isn't available things just continue on without the manuals.