### PR TITLE
Rename ecp-cookie-init to ecp-get-cookie

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ test_script:
   # run automated tests
   - python -m pytest --pyargs ciecplib --cov ciecplib --cov-report "" --junitxml=junit.xml
   # run --help on scripts for sanity
+  - python -m coverage run --append -m ciecplib.tool.ecp_cert_info --help
   - python -m coverage run --append -m ciecplib.tool.ecp_curl --help
   - python -m coverage run --append -m ciecplib.tool.ecp_get_cert --help
   - python -m coverage run --append -m ciecplib.tool.ecp_get_cookie --help

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,9 +18,9 @@ test_script:
   # run automated tests
   - python -m pytest --pyargs ciecplib --cov ciecplib --cov-report "" --junitxml=junit.xml
   # run --help on scripts for sanity
-  - python -m coverage run --append -m ciecplib.tool.ecp_cookie_init --help
   - python -m coverage run --append -m ciecplib.tool.ecp_curl --help
   - python -m coverage run --append -m ciecplib.tool.ecp_get_cert --help
+  - python -m coverage run --append -m ciecplib.tool.ecp_get_cookie --help
 after_test:
   - python -m coverage report
   - python -m pip install codecov

--- a/ciecplib/tool/ecp_get_cookie.py
+++ b/ciecplib/tool/ecp_get_cookie.py
@@ -20,11 +20,11 @@ r"""Authenticate and store SAML/ECP session cookies.
 
 There are two usages:
 
-    $ ecp-get-cookie 'My Institution' https://campus01.edu/my/secret/page jsmith
+    $ ecp-get-cookie -i 'My Institution' -u jsmith https://campus01.edu/my/secret/page
 
 to authenticate with a password prompt, or
 
-    $ ecp-get-cookie 'My Institution' https://campus01.edu/my/secret/page
+    $ ecp-get-cookie -i 'My Institution' -k https://campus01.edu/my/secret/page
 
 to reuse an existing kerberos (``kinit``) credential.
 

--- a/ciecplib/tool/ecp_get_cookie.py
+++ b/ciecplib/tool/ecp_get_cookie.py
@@ -20,11 +20,11 @@ r"""Authenticate and store SAML/ECP session cookies.
 
 There are two usages:
 
-    $ ecp-cookie-init 'My Institution' https://campus01.edu/my/secret/page jsmith
+    $ ecp-get-cookie 'My Institution' https://campus01.edu/my/secret/page jsmith
 
 to authenticate with a password prompt, or
 
-    $ ecp-cookie-init 'My Institution' https://campus01.edu/my/secret/page
+    $ ecp-get-cookie 'My Institution' https://campus01.edu/my/secret/page
 
 to reuse an existing kerberos (``kinit``) credential.
 
@@ -63,7 +63,7 @@ def create_parser():
     """
     parser = ArgumentParser(
         description=__doc__,
-        prog="ecp-cookie-init",
+        prog="ecp-get-cookie",
     )
     parser.add_argument(
         "target_url",

--- a/docs/ecp-cookie-init.rst
+++ b/docs/ecp-cookie-init.rst
@@ -1,6 +1,0 @@
-ecp-cookie-init
-===============
-
-.. argparse::
-   :ref: ciecplib.tool.ecp_cookie_init.create_parser
-   :prog: ecp-cookie-init

--- a/docs/ecp-get-cookie.rst
+++ b/docs/ecp-get-cookie.rst
@@ -1,0 +1,6 @@
+ecp-get-cookie
+==============
+
+.. argparse::
+   :ref: ciecplib.tool.ecp_get_cookie.create_parser
+   :prog: ecp-get-cookie

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,9 +69,9 @@ Command-line scripts
    :maxdepth: 1
 
    ecp-cert-info
-   ecp-cookie-init
    ecp-curl
    ecp-get-cert
+   ecp-get-cookie
 
 |
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,9 @@ universal = 1
 [build_manpages]
 manpages =
 	man/ecp-cert-info.1:function=create_parser:module=ciecplib.tool.ecp_cert_info
-	man/ecp-cookie-init.1:function=create_parser:module=ciecplib.tool.ecp_cookie_init
 	man/ecp-curl.1:function=create_parser:module=ciecplib.tool.ecp_curl
 	man/ecp-get-cert.1:function=create_parser:module=ciecplib.tool.ecp_get_cert
+	man/ecp-get-cookie.1:function=create_parser:module=ciecplib.tool.ecp_get_cookie
 
 ; -- tools
 

--- a/setup.py
+++ b/setup.py
@@ -122,9 +122,9 @@ setup(
     entry_points={
         "console_scripts": [
             "ecp-cert-info=ciecplib.tool.ecp_cert_info:main",
-            "ecp-cookie-init=ciecplib.tool.ecp_cookie_init:main",
             "ecp-curl=ciecplib.tool.ecp_curl:main",
             "ecp-get-cert=ciecplib.tool.ecp_get_cert:main",
+            "ecp-get-cookie=ciecplib.tool.ecp_get_cookie:main",
         ],
     },
     # dependencies


### PR DESCRIPTION
This PR renames the `ecp-cookit-init` tool to `ecp-get-cookie` to make it a little more intuitive, and similar to the `ecp-get-cert` tool.