### PR TITLE
Use %pypi_source macro in spec file

### DIFF
--- a/ciecplib.spec
+++ b/ciecplib.spec
@@ -13,7 +13,7 @@ Name:      %{name}
 Packager:  %{author} <%{email}>
 Prefix:    %{_prefix}
 Release:   %{release}%{?dist}
-Source0:   https://pypi.io/packages/source/l/%{name}/%{name}-%{version}.tar.gz
+Source0:   %pypi_source
 Summary:   A python client for SAML ECP authentication
 Url:       https://github.com/duncanmmacleod/ciecplib
 Vendor:    Duncan Macleod <duncan.macleod@ligo.org>


### PR DESCRIPTION
This PR updates the spec file to use the `%pypi_source` macro.