### PR TITLE
Add --valid option to ecp-cert-info

### DIFF
--- a/ciecplib/tool/ecp_get_cert.py
+++ b/ciecplib/tool/ecp_get_cert.py
@@ -164,14 +164,14 @@ def create_parser():
     return parser
 
 
-def parse_args(parser):
+def parse_args(parser, args=None):
     """Parse and validate the command-line arguments
 
     Returns
     -------
     args : `argparse.Namespace`
     """
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
 
     # check that username or --kerberos was given if not using --destroy
     if not args.destroy and not (
@@ -193,9 +193,9 @@ def can_reuse(path, proxy=None):
     return True
 
 
-def main():
+def main(args=None):
     parser = create_parser()
-    args = parse_args(parser)
+    args = parse_args(parser, args=args)
 
     if args.debug:
         init_logging()

--- a/ciecplib/tool/ecp_get_cookie.py
+++ b/ciecplib/tool/ecp_get_cookie.py
@@ -125,14 +125,14 @@ def create_parser():
     return parser
 
 
-def parse_args(parser):
+def parse_args(parser, args=None):
     """Parse and validate the command-line arguments
 
     Returns
     -------
     args : `argparse.Namespace`
     """
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
 
     # check that username or --kerberos was given if not using --destroy
     if not args.destroy and not (
@@ -148,9 +148,9 @@ def parse_args(parser):
     return args
 
 
-def main():
+def main(args=None):
     parser = create_parser()
-    args = parse_args(parser)
+    args = parse_args(parser, args=args)
 
     if args.debug:
         init_logging()

--- a/ciecplib/tool/tests/test_ecp_cert_info.py
+++ b/ciecplib/tool/tests/test_ecp_cert_info.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2020)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`ciecplib.tool.ecp_cert_info`
+"""
+
+try:
+    from unittest import mock
+except ImportError:  # python < 3
+    import mock
+
+import pytest
+
+from .. import ecp_cert_info
+
+
+@mock.patch("ciecplib.tool.ecp_cert_info.load_cert", mock.Mock())
+@mock.patch("ciecplib.tool.ecp_cert_info.print_cert_info", mock.Mock())
+@mock.patch(
+    "ciecplib.tool.ecp_cert_info.time_left",
+    mock.Mock(side_effect=(3700., 3500.)),
+)
+def test_valid():
+    """Check that the --valid option for ecp-cert-info works
+    """
+    ecp_cert_info.main(["--valid", "1:0"])
+    with pytest.raises(AssertionError):
+        ecp_cert_info.main(["--valid", "1:0"])

--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -61,7 +61,7 @@ def load_cert(path, format=crypto.FILETYPE_PEM):
         )
 
 
-def _timeleft(cert):
+def time_left(cert):
     """Returns the number of seconds left on this certificate
     """
     try:  # M2Crypto
@@ -102,7 +102,7 @@ def check_cert(cert, hours=1, proxy=None, rfc3820=True):
         is RFC 3820 compliant
     """
     # check expiry
-    remaining = _timeleft(cert)
+    remaining = time_left(cert)
     if remaining < hours * 3600.:
         raise RuntimeError(
             "less than {0} hours remaining on X509 certificate".format(hours)
@@ -156,7 +156,7 @@ def print_cert_info(x509, path=None, verbose=True):
     print("strength : {0} bits".format(pkey.bits()))
     if path:
         print("path     : " + str(path))
-    print("timeleft : " + str(datetime.timedelta(seconds=_timeleft(x509))))
+    print("timeleft : " + str(datetime.timedelta(seconds=time_left(x509))))
 
 
 def write_cert(path, pkcs12, use_proxy=False, minhours=168):


### PR DESCRIPTION
This PR adds a `--valid` option to `ecp-cert-info` that mirrors the `-valid` option for `grid-proxy-info` from globus.