### PR TITLE
Actually use level argument in init_logging function

### DIFF
--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -76,9 +76,10 @@ def test_list_idps_action(capsys):
     assert "'Cardiff University'" in stdout
 
 
+@mock.patch.dict(logging.Logger.manager.loggerDict)
 @mock.patch("{}.HTTPConnection.debuglevel".format(http_client.__name__))
 def test_init_logging(_):
-    log = tools_utils.init_logging(logging.INFO)
+    log = tools_utils.init_logging(logging.FATAL)
     assert http_client.HTTPConnection.debuglevel == 1
     assert log is logging.Logger.manager.loggerDict["urllib3"]
-    assert log.level == logging.INFO
+    assert log.level == logging.FATAL

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -20,11 +20,17 @@
 """
 
 import argparse
+import logging
 import sys
 try:
-    from urllib.error import URLError
+    from unittest import mock
 except ImportError:  # python < 3
+    import mock
+    import httplib as http_client
     from urllib2 import URLError
+else:
+    from http import client as http_client
+    from urllib.error import URLError
 
 import pytest
 
@@ -68,3 +74,11 @@ def test_list_idps_action(capsys):
             pytest.skip(str(exc))
     stdout = capsys.readouterr()[0]
     assert "'Cardiff University'" in stdout
+
+
+@mock.patch("{}.HTTPConnection.debuglevel".format(http_client.__name__))
+def test_init_logging(_):
+    log = tools_utils.init_logging(logging.INFO)
+    assert http_client.HTTPConnection.debuglevel == 1
+    assert log is logging.Logger.manager.loggerDict["urllib3"]
+    assert log.level == logging.INFO

--- a/ciecplib/tool/utils.py
+++ b/ciecplib/tool/utils.py
@@ -190,8 +190,8 @@ def init_logging(level=logging.DEBUG):
     """
     HTTPConnection.debuglevel = 1
     logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger().setLevel(level)
     requests_log = logging.getLogger("urllib3")
-    requests_log.setLevel(logging.DEBUG)
+    requests_log.setLevel(level)
     requests_log.propagate = True
     return requests_log


### PR DESCRIPTION
This PR patches `ciecplib.tool.utils.init_logging` to actually use the `level` positional argument.