### PR TITLE
Use pathlib instead of os.path

### DIFF
--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -20,6 +20,7 @@
 """
 
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -41,26 +42,26 @@ RAW_IDP_LIST = "\n".join(
 
 @mock.patch(
     "os.getlogin" if os.name == "nt" else "os.getuid",
-    return_value=123,
+    mock.MagicMock(return_value=123),
 )
-def test_get_ecpcookie_path(_):
+def test_get_ecpcookie_path():
     if os.name == "nt":
         path = r"%SYSTEMROOT%\Temp\ecpcookie.123"
     else:
         path = "/tmp/ecpcookie.u123"
-    assert ciecplib_utils.get_ecpcookie_path() == path
+    assert ciecplib_utils.get_ecpcookie_path() == Path(path)
 
 
 @mock.patch(
     "os.getlogin" if os.name == "nt" else "os.getuid",
-    return_value=123,
+    mock.MagicMock(return_value=123),
 )
-def get_x509_proxy_path():
+def test_get_x509_proxy_path():
     if os.name == "nt":
         path = r"%SYSTEMROOT%\Temp\x509up_123"
     else:
         path = "/tmp/x509up_u123"
-    assert ciecplib_utils.get_x509_proxy_path() == path
+    assert ciecplib_utils.get_x509_proxy_path() == Path(path)
 
 
 def test_get_idps(requests_mock):

--- a/ciecplib/utils.py
+++ b/ciecplib/utils.py
@@ -16,10 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
 
-import os.path
+import os
 import random
 import re
 import string
+from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
@@ -29,14 +30,24 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 # -- default paths ------------------------------------------------------------
 
-def get_ecpcookie_path():
+def _tmpfile(prefix):
     if os.name == "nt":
         tmpdir = r'%SYSTEMROOT%\Temp'
-        tmpname = "ecpcookie.{0}".format(os.getlogin())
+        user = os.getlogin()
     else:
         tmpdir = "/tmp"
-        tmpname = "ecpcookie.u{0}".format(os.getuid())
-    return os.path.join(tmpdir, tmpname)
+        user = "u{}".format(os.getuid())
+    return Path(tmpdir) / "{}{}".format(prefix, user)
+
+
+def get_ecpcookie_path():
+    """Returns the default path for the ECP cookie file
+
+    Returns
+    -------
+    path : `pathlib.Path`
+    """
+    return _tmpfile("ecpcookie.")
 
 
 def get_x509_proxy_path():
@@ -44,21 +55,15 @@ def get_x509_proxy_path():
 
     Returns
     -------
-    path : `str`
+    path : `pathlib.Path`
     """
     if os.getenv("X509_USER_PROXY"):
-        return os.environ["X509_USER_PROXY"]
-    if os.name == "nt":
-        tmpdir = r'%SYSTEMROOT%\Temp'
-        tmpname = "x509up_{0}".format(os.getlogin())
-    else:
-        tmpdir = "/tmp"
-        tmpname = "x509up_u{0}".format(os.getuid())
-    return os.path.join(tmpdir, tmpname)
+        return Path(os.environ["X509_USER_PROXY"])
+    return _tmpfile("x509up_")
 
 
-DEFAULT_COOKIE_FILE = get_ecpcookie_path()
-DEFAULT_X509_USER_FILE = get_x509_proxy_path()
+DEFAULT_COOKIE_FILE = str(get_ecpcookie_path())
+DEFAULT_X509_USER_FILE = str(get_x509_proxy_path())
 
 # -- institution URLs ----------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@
 """Build configuration for ciecplib
 """
 
-import os.path
 import re
+from pathlib import Path
 
 from setuptools import (find_packages, setup)
 from setuptools.command.build_py import build_py
@@ -50,7 +50,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 def find_version(path, varname="__version__"):
     """Parse the version metadata in the given file.
     """
-    with open(path, 'r') as fobj:
+    with path.open('r') as fobj:
         version_file = fobj.read()
     version_match = re.search(
         r"^{0} = ['\"]([^'\"]*)['\"]".format(varname),
@@ -90,7 +90,7 @@ extras_require = {
 setup(
     # distribution metadata
     name="ciecplib",
-    version=find_version(os.path.join("ciecplib", "__init__.py")),
+    version=find_version(Path("ciecplib") / "__init__.py"),
     author="Duncan Macleod",
     author_email="duncan.macleod@ligo.org",
     license="GPL-3.0-or-later",


### PR DESCRIPTION
This PR updates this library to use `pathlib` where appropriate instead of `os.path`.