### PR TITLE
Don't build universal wheels 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,7 @@
 ; -- build
 
 [metadata]
-license_file = LICENSE
-
-[bdist_wheel]
-universal = 1
+license_files = LICENSE
 
 [build_manpages]
 manpages =


### PR DESCRIPTION
This PR removes the `universal` flag for `bdist_wheel` in `setup.cfg` since we don't support python2.