### PR TITLE
Use shutil.move in x509.write_cert

### DIFF
--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -18,7 +18,7 @@
 
 import calendar
 import datetime
-import os
+import shutil
 import struct
 import tempfile
 import time
@@ -199,7 +199,7 @@ def write_cert(path, pkcs12, use_proxy=False, minhours=168):
         tmp.close()
 
         # move tmpfile into place
-        os.rename(tmp.name, path)
+        shutil.move(tmp.name, path)
 
 
 def generate_proxy(cert, key, minhours=168, limited=False, bits=2048):


### PR DESCRIPTION
This PR fixes a corner-case issue with `ciecplib.x509.write_cert`, since `os.rename` doesn't work across filesystems.