### PR TITLE
Add unit tests for ciecplib.x509

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
     environment:
       PYTHON_VERSION: "3.7"
 
-  centos:8:3.6:
+  rhel:centos8:3.6:
     <<: *centos
     docker:
       - image: centos:8
@@ -363,7 +363,7 @@ workflows:
       - flake8
       - sphinx
       # -- stage 2
-      - centos:8:3.6:
+      - rhel:centos8:3.6:
           requires:
             - sdist
       - debian:buster:3.7:

--- a/ciecplib/tests/conftest.py
+++ b/ciecplib/tests/conftest.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2020)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Common fixtures for ciecplib tests
+"""
+
+import tempfile
+from pathlib import Path
+
+from OpenSSL import crypto
+from M2Crypto import (
+    X509 as m2X509,
+    EVP as m2EVP,
+)
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def pkey():
+    key = crypto.PKey()
+    key.generate_key(crypto.TYPE_RSA, 1024)
+    return key
+
+
+@pytest.fixture(scope="session")
+def x509(pkey):
+    cert = crypto.X509()
+    sub = cert.get_subject()
+    sub.CN = "localhost"
+    sub.C = "UK"
+    sub.ST = "Wales"
+    sub.L = "Cardiff"
+    sub.O = "Cardiff University"  # noqa: E741
+    sub.OU = "Gravity"
+    cert.set_serial_number(1000)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(86400)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(pkey)
+    cert.sign(pkey, "sha256")
+    return cert
+
+
+@pytest.fixture(scope="session")
+def x509_path(x509):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "tmpx509.pem"
+        with path.open("wb") as tmp:
+            tmp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, x509))
+        yield path
+
+
+@pytest.fixture(scope="session")
+def x509_m2(x509):
+    return m2X509.load_cert_string(
+        crypto.dump_certificate(crypto.FILETYPE_PEM, x509),
+    )
+
+
+@pytest.fixture(scope="session")
+def pkey_m2(pkey):
+    return m2EVP.load_key_string(
+        crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey),
+    )
+
+
+@pytest.fixture(scope="session")
+def pkcs12(pkey, x509):
+    p12 = crypto.PKCS12()
+    p12.set_privatekey(pkey)
+    p12.set_certificate(x509)
+    return p12

--- a/ciecplib/tests/test_x509.py
+++ b/ciecplib/tests/test_x509.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2020)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suite for :mod:`cieclib.x509`
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from .. import x509 as ciecplib_x509
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+def test_load_cert(x509_path):
+    x509 = ciecplib_x509.load_cert(x509_path)
+    assert x509.get_subject().hash() == 565972249
+
+
+@pytest.mark.parametrize("lib", ("openssl", "m2crypto"))
+def test_time_left(x509, x509_m2, lib):
+    cert = {
+        "openssl": x509,
+        "m2crypto": x509_m2,
+    }[lib]
+    assert ciecplib_x509.time_left(cert) <= 86400
+
+
+@mock.patch("ciecplib.x509.time_left", mock.MagicMock(return_value=4000))
+def test_check_cert(x509):
+    ciecplib_x509.check_cert(x509, hours=1, proxy=False, rfc3820=False)
+
+
+@mock.patch("ciecplib.x509.time_left", mock.MagicMock(return_value=4000))
+def test_check_cert_time(x509):
+    with pytest.raises(RuntimeError):
+        ciecplib_x509.check_cert(x509, hours=2)
+
+
+@pytest.mark.parametrize("proxy, certtype", [
+    (True, "end entity credential"),
+    (False, "some sort of proxy"),
+])
+@mock.patch("ciecplib.x509._cert_type")
+@mock.patch("ciecplib.x509.time_left", mock.MagicMock(return_value=4000))
+def test_check_cert_proxy_errors(mock_cert_type, x509, proxy, certtype):
+    mock_cert_type.return_value = certtype
+    with pytest.raises(RuntimeError):
+        ciecplib_x509.check_cert(x509, hours=1, proxy=proxy)
+
+
+@mock.patch(
+    "ciecplib.x509._cert_type",
+    mock.MagicMock(return_value="legacy globus proxy"),
+)
+@mock.patch("ciecplib.x509.time_left", mock.MagicMock(return_value=4000))
+def test_check_cert_rfc3820_error(x509):
+    with pytest.raises(RuntimeError):
+        ciecplib_x509.check_cert(x509, hours=1, rfc3820=True)
+
+
+def test_print_cert_info(x509, capsys):
+    ciecplib_x509.print_cert_info(
+        x509,
+        path="test",
+        verbose=True,
+        stream=sys.stdout,
+    )
+    out = capsys.readouterr().out
+    assert out.startswith("-----BEGIN CERTIFICATE-----")
+    assert (
+        "subject  : /CN=localhost/C=UK/ST=Wales/L=Cardiff"
+        "/O=Cardiff University/OU=Gravity"
+    ) in out
+    assert "path     : test" in out
+
+
+@pytest.mark.parametrize('proxy', (False, True))
+def test_write_cert(pkcs12, proxy):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "509.pem"
+        # write the p12 cert to a file
+        ciecplib_x509.write_cert(path, pkcs12, use_proxy=proxy)
+        # check that we can read it
+        assert (
+            ciecplib_x509.load_cert(path).get_issuer().hash()
+        ) == 565972249
+
+
+@pytest.mark.parametrize("limited, ctype", [
+    (False, "RFC 3820 compliant impersonation proxy"),
+    (True, "RFC 3820 compliant limited proxy"),
+])
+def test_generate_proxy(pkey_m2, x509_m2, limited, ctype):
+    proxy, pkey = ciecplib_x509.generate_proxy(
+        x509_m2,
+        pkey_m2.get_rsa(),
+        limited=limited,
+    )
+    assert ciecplib_x509._cert_type(proxy) == ctype

--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -42,7 +42,7 @@ def load_cert(path, format=crypto.FILETYPE_PEM):
 
     Parameters
     ----------
-    path : `str`
+    path : `str`, `pathlib.Path`
         the file path from which to read
 
     format : `int`, optional
@@ -53,7 +53,7 @@ def load_cert(path, format=crypto.FILETYPE_PEM):
     cert : `OpenSSL.crypto.X509`
         the parsed certificate
     """
-    with open(path, "r") as fobj:
+    with open(str(path), "r") as fobj:
         return crypto.load_certificate(
             format,
             fobj.read(),

--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -214,7 +214,7 @@ def write_cert(path, pkcs12, use_proxy=False, minhours=168):
 
     Parameters
     ----------
-    path : `str`
+    path : `str`, `pathlib.Path`
         the desired location of the final X509 file
 
     pkcs12 : `OpenSSL.crypto.PKCS12`
@@ -251,7 +251,7 @@ def write_cert(path, pkcs12, use_proxy=False, minhours=168):
         tmp.close()
 
         # move tmpfile into place
-        shutil.move(tmp.name, path)
+        shutil.move(tmp.name, str(path))
 
 
 def generate_proxy(cert, key, minhours=168, limited=False, bits=2048):

--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -20,6 +20,7 @@ import calendar
 import datetime
 import shutil
 import struct
+import sys
 import tempfile
 import time
 
@@ -120,41 +121,92 @@ def check_cert(cert, hours=1, proxy=None, rfc3820=True):
 def _cert_type(x509):
     """Returns the type of the given x509 certificate object
     """
+    # convert openssl to m2crypto for convenience
+    if isinstance(x509, crypto.X509):
+        x509 = X509.load_cert_string(crypto.dump_certificate(
+            crypto.FILETYPE_PEM,
+            x509,
+        ))
     # parse name entry as common name
-    sub = x509.get_subject().get_components()
-    if sub[-1][0] != b"CN":
+    sub = x509.get_subject()
+    ntype, name = sub.as_text().split()[-1].split('=', 1)
+
+    # if name entry is not 'common name' then EEC
+    if ntype != "CN":
         return "end entity credential"
-    if sub[-1][1] == "proxy":
+
+    # if we get here, it's a proxy of some sort
+
+    if name == "proxy":
         return "full legacy globus proxy"
-    if sub[-1][1] == "limited proxy":
+    if name == "limited proxy":
         return "limited legacy globus proxy"
 
-    # parse extensions for proxyCertInfo
-    extensions = [x509.get_extension(i) for
-                  i in range(x509.get_extension_count())]
-    names = [e.get_short_name() for e in extensions]
-    if b"proxyCertInfo" in names:
-        return "RFC 3820 compliant impersonation proxy"
-    return "end entity credential"
+    # get policy language
+    try:
+        policy = _get_cert_policy_language(x509)
+    except (KeyError, ValueError):
+        pass
+    else:
+        if policy == "1.3.6.1.4.1.3536.1.1.1.9":
+            return "RFC 3820 compliant limited proxy"
+        if policy == "Inherit all":
+            return "RFC 3820 compliant impersonation proxy"
+        return "RFC 3820 compliant restricted proxy"
+
+    return "unidentified proxy"
 
 
-def print_cert_info(x509, path=None, verbose=True):
+def _get_cert_policy_language(x509):
+    for i in range(x509.get_ext_count()):
+        ext = x509.get_ext_at(i)
+        name = ext.get_name()
+        if (
+            name == "proxyCertInfo" and
+            ext.get_critical()
+        ):
+            pcidata = dict(
+                map(str.strip, line.split(':', 1)) for
+                line in ext.get_value().rstrip().split('\n')
+            )
+            return pcidata["Policy Language"]
+    raise ValueError("no policy language found in cert")
+
+
+def print_cert_info(x509, path=None, verbose=True, stream=sys.stdout):
     """Print info about an X.509 certificate
+
+    Parameters
+    ----------
+    x509 : `OpenSSL.crypto.X509`
+        the certificate to parse
+
+    path : `str`, optional
+        the path of the certificate file on disk
+
+    verbose : `bool`, optional
+        if `True` (default) print the full text of the certificate
+
+    stream : `file`, optional
+        the file object to print to, defaults to `sys.stdout`
     """
     if verbose:
         certstr = crypto.dump_certificate(
             crypto.FILETYPE_PEM,
             x509,
         )
-        print(certstr.decode("utf-8"), end="")
+        print(certstr.decode("utf-8"), file=stream, end="")
     pkey = x509.get_pubkey()
-    print("subject  : " + _x509_name_str(x509.get_subject()))
-    print("issuer   : " + _x509_name_str(x509.get_issuer()))
-    print("type     : " + _cert_type(x509))
-    print("strength : {0} bits".format(pkey.bits()))
+    print("subject  : " + _x509_name_str(x509.get_subject()), file=stream)
+    print("issuer   : " + _x509_name_str(x509.get_issuer()), file=stream)
+    print("type     : " + _cert_type(x509), file=stream)
+    print("strength : {0} bits".format(pkey.bits()), file=stream)
     if path:
-        print("path     : " + str(path))
-    print("timeleft : " + str(datetime.timedelta(seconds=time_left(x509))))
+        print("path     : " + str(path), file=stream)
+    print(
+        "timeleft : " + str(datetime.timedelta(seconds=time_left(x509))),
+        file=stream,
+    )
 
 
 def write_cert(path, pkcs12, use_proxy=False, minhours=168):
@@ -209,6 +261,14 @@ def generate_proxy(cert, key, minhours=168, limited=False, bits=2048):
     https://github.com/abbot/gridproxy/blob/master/gridproxy/__init__.py
     which is Copyright Lev Shamardin and covered under the GNU GPLv3 license.
 
+    Parameters
+    ----------
+    cert : `M2Crypto.X509.X509`
+        the certificate object
+
+    key : `M2Crypto.RSA.RSA_pub`
+        the RSA key object
+
     Returns
     -------
     proxycert : `M2Crypto.X509.X509`
@@ -236,9 +296,7 @@ def generate_proxy(cert, key, minhours=168, limited=False, bits=2048):
     not_after_time = now + int(minhours * 60 * 60)
     # make sure proxy doesn't expire later than the underlying cert
     cert_not_after_time = _parse_unix_time(cert.get_not_after())
-    if not_after_time > cert_not_after_time:
-        not_after_time = cert_not_after_time
-    not_after.set_time(not_after_time)
+    not_after.set_time(min(not_after_time, cert_not_after_time))
     proxy.set_not_after(not_after)
 
     proxy.set_issuer_name(cert.get_subject())


### PR DESCRIPTION
This PR improves the `ciecplib.x509` module as follows:

- added unit tests
- new `stream` keyword for `print_cert_info`
- `_cert_type` now uses `M2Crypto.X509.X509` format internally throughout