### PR TITLE
Add tests for ciecplib.cookies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,9 @@ install:
         "python=%PYTHON_VERSION%"
         "pip"
         "setuptools>=27.3"
-  - conda install --quiet --yes --name ciecplib --file requirements.txt
+  - conda install --quiet --yes --name ciecplib
+        --file requirements.txt
+        --file requirements-test.txt
   - conda activate ciecplib
   - conda info
   - conda list

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,6 @@ environment:
   global:
     MINICONDA: C:\Miniconda3-x64
   matrix:
-    - PYTHON_VERSION: 3.5
     - PYTHON_VERSION: 3.6
     - PYTHON_VERSION: 3.7
     - PYTHON_VERSION: 3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,6 @@ aliases:
               python${PYTHON_VERSION:0:1}-pytest-cov \
               python${PYTHON_VERSION:0:1}-requests-mock \
           ;
-          python${PYTHON_VERSION} -m pip install "pytest~=3.0"
 
   - &test
       run:
@@ -174,7 +173,8 @@ aliases:
         command: |
           set -x;
           # install test requirements
-          python${PYTHON_VERSION} -m pip install "pytest" "pytest-cov" "requests-mock" "zipp<2.0.0"
+          python${PYTHON_VERSION} -m pip install "pip >=9.0.0"
+          python${PYTHON_VERSION} -m pip install -r requirements-test.txt
           # run test suite
           mkdir -pv tests;
           pushd tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,13 @@ before_install:
   - conda info --all
 
 install:
-  - travis_retry conda create --quiet --name ci python=${PYTHON_VERSION} pip setuptools
-  - travis_retry conda install --quiet --yes --name ci --file requirements.txt
+  - travis_retry conda create --quiet --name ci
+        python=${PYTHON_VERSION}
+        pip
+        setuptools
+  - travis_retry conda install --quiet --yes --name ci
+        --file requirements.txt
+        --file requirements-test.txt
   - travis_retry conda activate ci
   # install this version
   - python -m pip install --editable .

--- a/ciecplib/cookies.py
+++ b/ciecplib/cookies.py
@@ -37,7 +37,7 @@ class ECPCookieJar(RequestsCookieJar, MozillaCookieJar):
     https://wiki.shibboleth.net/confluence/download/attachments/4358416/ecp.py
     """
     def save(self, filename=None, ignore_discard=False, ignore_expires=False):
-        with open(filename, 'w') as f:
+        with open(str(filename), 'w') as f:
             f.write(self.header)
             for cookie in self:
                 if not ignore_discard and cookie.discard:

--- a/ciecplib/tests/conftest.py
+++ b/ciecplib/tests/conftest.py
@@ -28,14 +28,14 @@ from M2Crypto import (
 import pytest
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def pkey():
     key = crypto.PKey()
     key.generate_key(crypto.TYPE_RSA, 1024)
     return key
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def x509(pkey):
     cert = crypto.X509()
     sub = cert.get_subject()
@@ -54,7 +54,7 @@ def x509(pkey):
     return cert
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def x509_path(tmp_path, x509):
     path = tmp_path / "tmpx509.pem"
     with path.open("wb") as tmp:
@@ -62,21 +62,21 @@ def x509_path(tmp_path, x509):
     return path
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def x509_m2(x509):
     return m2X509.load_cert_string(
         crypto.dump_certificate(crypto.FILETYPE_PEM, x509),
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def pkey_m2(pkey):
     return m2EVP.load_key_string(
         crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey),
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def pkcs12(pkey, x509):
     p12 = crypto.PKCS12()
     p12.set_privatekey(pkey)

--- a/ciecplib/tests/conftest.py
+++ b/ciecplib/tests/conftest.py
@@ -19,9 +19,6 @@
 """Common fixtures for ciecplib tests
 """
 
-import tempfile
-from pathlib import Path
-
 from OpenSSL import crypto
 from M2Crypto import (
     X509 as m2X509,
@@ -58,12 +55,11 @@ def x509(pkey):
 
 
 @pytest.fixture(scope="session")
-def x509_path(x509):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / "tmpx509.pem"
-        with path.open("wb") as tmp:
-            tmp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, x509))
-        yield path
+def x509_path(tmp_path, x509):
+    path = tmp_path / "tmpx509.pem"
+    with path.open("wb") as tmp:
+        tmp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, x509))
+    return path
 
 
 @pytest.fixture(scope="session")

--- a/ciecplib/tests/test_cookies.py
+++ b/ciecplib/tests/test_cookies.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2020)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suite for :mod:`ciecplib.cookies`
+"""
+
+import tempfile
+from http.cookiejar import Cookie
+
+import pytest
+
+from ciecplib import cookies as ciecplib_cookies
+
+
+@pytest.fixture
+def sessioncookie():
+    return Cookie(
+        version=0,
+        name="_shibsession_1234567890",
+        value="_1234567890",
+        port=None,
+        port_specified=False,
+        domain="somewhere.test.com",
+        domain_specified=False,
+        domain_initial_dot=False,
+        path="/",
+        path_specified=True,
+        secure=True,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={"HttpOnly": None},
+        rfc2109=False,
+    )
+
+
+@pytest.fixture
+def ecpcookiejar(sessioncookie):
+    jar = ciecplib_cookies.ECPCookieJar()
+    jar.set_cookie(sessioncookie)
+    return jar
+
+
+class TestECPCookieJar(object):
+    TEST_CLASS = ciecplib_cookies.ECPCookieJar
+
+    def test_save_discard(self, ecpcookiejar, tmp_path):
+        path = tmp_path / "cookies"
+        ecpcookiejar.save(path)
+        # check that the header got written
+        assert path.open("r").read().startswith(ecpcookiejar.header)
+        # check that there aren't actually any cookies
+        # (since the cookie is a session cookie [`discard=True`])
+        jar = self.TEST_CLASS()
+        jar.load(path)
+        assert len(jar) == 0
+
+    def test_save_ignore_discard(self, ecpcookiejar, tmp_path):
+        path = tmp_path / "cookies"
+        ecpcookiejar.save(path, ignore_discard=True, ignore_expires=True)
+        jar = self.TEST_CLASS()
+        jar.load(path, ignore_discard=True, ignore_expires=True)
+        assert jar["_shibsession_1234567890"] == "_1234567890"
+
+
+def test_extract_session_cookie(ecpcookiejar, sessioncookie):
+    assert ciecplib_cookies.extract_session_cookie(
+        ecpcookiejar,
+        "https://somewhere.test.com/blah/blah",
+    ) is sessioncookie
+
+
+def test_extract_session_cookie_error(ecpcookiejar):
+    with pytest.raises(ValueError):
+        ciecplib_cookies.extract_session_cookie(
+            ecpcookiejar,
+            "https://somethingelse.test.com",
+        )
+
+
+@pytest.mark.parametrize("url, result", [
+    ("https://somewhere.test.com", True),
+    ("https://somewhereelse.test.com", False),
+])
+def test_has_session_cookies(ecpcookiejar, url, result):
+    assert ciecplib_cookies.has_session_cookies(ecpcookiejar, url) is result
+
+
+def test_load_cookiejar(ecpcookiejar, tmp_path):
+    path = tmp_path / "cookies"
+    ecpcookiejar.save(path, ignore_discard=True, ignore_expires=True)
+    jar = ciecplib_cookies.load_cookiejar(path)
+    assert jar == ecpcookiejar
+
+
+def test_load_cookiejar_error(tmp_path):
+    with pytest.raises(OSError):
+        ciecplib_cookies.load_cookiejar(tmp_path / "blah")
+    assert isinstance(
+        ciecplib_cookies.load_cookiejar(tmp_path / "blah", strict=False),
+        ciecplib_cookies.ECPCookieJar,
+    )

--- a/ciecplib/tests/test_cookies.py
+++ b/ciecplib/tests/test_cookies.py
@@ -19,7 +19,6 @@
 """Test suite for :mod:`ciecplib.cookies`
 """
 
-import tempfile
 from http.cookiejar import Cookie
 
 import pytest

--- a/ciecplib/tests/test_cookies.py
+++ b/ciecplib/tests/test_cookies.py
@@ -67,14 +67,14 @@ class TestECPCookieJar(object):
         # check that there aren't actually any cookies
         # (since the cookie is a session cookie [`discard=True`])
         jar = self.TEST_CLASS()
-        jar.load(path)
+        jar.load(str(path))
         assert len(jar) == 0
 
     def test_save_ignore_discard(self, ecpcookiejar, tmp_path):
         path = tmp_path / "cookies"
         ecpcookiejar.save(path, ignore_discard=True, ignore_expires=True)
         jar = self.TEST_CLASS()
-        jar.load(path, ignore_discard=True, ignore_expires=True)
+        jar.load(str(path), ignore_discard=True, ignore_expires=True)
         assert jar["_shibsession_1234567890"] == "_1234567890"
 
 

--- a/ciecplib/tests/test_x509.py
+++ b/ciecplib/tests/test_x509.py
@@ -20,8 +20,6 @@
 """
 
 import sys
-import tempfile
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -95,15 +93,14 @@ def test_print_cert_info(x509, capsys):
 
 
 @pytest.mark.parametrize('proxy', (False, True))
-def test_write_cert(pkcs12, proxy):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / "509.pem"
-        # write the p12 cert to a file
-        ciecplib_x509.write_cert(path, pkcs12, use_proxy=proxy)
-        # check that we can read it
-        assert (
-            ciecplib_x509.load_cert(path).get_issuer().hash()
-        ) == 565972249
+def test_write_cert(tmp_path, pkcs12, proxy):
+    path = tmp_path / "509.pem"
+    # write the p12 cert to a file
+    ciecplib_x509.write_cert(path, pkcs12, use_proxy=proxy)
+    # check that we can read it
+    assert (
+        ciecplib_x509.load_cert(path).get_issuer().hash()
+    ) == 565972249
 
 
 @pytest.mark.parametrize("limited, ctype", [

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest >= 3.9.0
+pytest-cov >= 2.6.1
+requests-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--r requirements-test.txt
 M2Crypto
 pyOpenSSL
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
+-r requirements-test.txt
 M2Crypto
 pyOpenSSL
-pytest >=3.9.0
-pytest-cov
 requests
 requests-ecp
-requests-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 M2Crypto
 pyOpenSSL
-pytest
+pytest >=3.9.0
 pytest-cov
 requests
 requests-ecp

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_requires = [
     "requests-ecp",  # GPL-3.0-or-later
 ]
 tests_require = [
-    "pytest",
+    "pytest >= 3.9.0",
     "pytest-cov",
     "requests-mock",
 ]


### PR DESCRIPTION
This PR adds a test suite for `ciecplib.cookies`, and adds support for `pathlib.Path` objects in all read/write operations.