### PR TITLE
Improve handling of cookie files

### DIFF
--- a/ciecplib/requests.py
+++ b/ciecplib/requests.py
@@ -21,9 +21,6 @@
 
 from .env import DEFAULT_IDP
 from .sessions import Session
-from .utils import (
-    DEFAULT_COOKIE_FILE,
-)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -39,8 +36,6 @@ def _ecp_session(func):
                 password=kwargs.pop("password", None),
                 kerberos=kwargs.pop("kerberos", False),
                 cookiejar=kwargs.pop("cookiejar", None),
-                cookiefile=kwargs.pop("cookiefile", DEFAULT_COOKIE_FILE),
-                store_cookies=kwargs.pop("store_cookies", False),
             )
         return func(*args, **kwargs)
     return _wrapper
@@ -80,10 +75,6 @@ _request_params_doc = """
 
     cookiejar : `http.cookielib.CookieJar`, optional
         a jar of cookies to add to the `requests.Session`.
-
-    cookiefile : `str`, optional
-        the path of a cookie file from which to read existing cookies,
-        this argument is ignored if ``cookiejar`` is given.
 
     kwargs
         other keyword arguments are passed directly to

--- a/ciecplib/tool/ecp_curl.py
+++ b/ciecplib/tool/ecp_curl.py
@@ -29,8 +29,8 @@ Currently only HTTP GET requests are supported (patches welcome!).
 
 import sys
 
-from .. import requests as ecp_requests
 from ..cookies import load_cookiejar
+from ..sessions import Session
 from ..utils import DEFAULT_COOKIE_FILE
 from .utils import (
     ArgumentParser,
@@ -101,18 +101,25 @@ def main(args=None):
     else:
         stream = sys.stdout
     try:
-        print(
-            ecp_requests.get(
-                args.url,
-                cookiejar=cookiejar,
-                endpoint=args.identity_provider,
-                username=args.username,
-                kerberos=args.kerberos,
-                store_cookies=args.store_session_cookies,
-            ).text,
-            file=stream,
-            end="",
-        )
+        with Session(
+            cookiejar=cookiejar,
+            idp=args.identity_provider,
+            username=args.username,
+            kerberos=args.kerberos,
+        ) as sess:
+            # GET
+            print(
+                sess.get(args.url).text,
+                file=stream,
+                end="",
+            )
+            # store session cookies
+            if args.store_session_cookies:
+                sess.cookies.save(
+                    args.cookiefile,
+                    ignore_discard=True,
+                    ignore_expires=True,
+                )
     finally:
         if args.output:
             stream.close()

--- a/ciecplib/tool/ecp_curl.py
+++ b/ciecplib/tool/ecp_curl.py
@@ -104,7 +104,6 @@ def main(args=None):
         print(
             ecp_requests.get(
                 args.url,
-                cookiefile=args.cookiefile,
                 cookiejar=cookiejar,
                 endpoint=args.identity_provider,
                 username=args.username,

--- a/ciecplib/tool/ecp_get_cookie.py
+++ b/ciecplib/tool/ecp_get_cookie.py
@@ -164,8 +164,7 @@ def main(args=None):
             args.target_url,
             endpoint=args.identity_provider,
             username=getattr(args, "username", None),
-            cookiejar=None,
-            cookiefile=None,
+            cookiejar=cookiejar,
             kerberos=args.kerberos,
             debug=args.debug,
         )


### PR DESCRIPTION
This PR improves and simplifies the way that cookie files are handled by removing the `cookiefile` keyword argument for `ciecplib.sessions.Session`.