### PR TITLE
Fix bug getting default X509 path on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,12 +297,12 @@ jobs:
     environment:
       PYTHON_VERSION: "3.7"
 
-  debian:bullseye:3.7:
+  debian:bullseye:3.8:
     <<: *debian
     docker:
       - image: debian:bullseye
     environment:
-      PYTHON_VERSION: "3.7"
+      PYTHON_VERSION: "3.8"
 
   rhel:centos8:3.6:
     <<: *centos
@@ -369,7 +369,7 @@ workflows:
       - debian:buster:3.7:
           requires:
             - sdist
-      - debian:bullseye:3.7:
+      - debian:bullseye:3.8:
           requires:
             - sdist
       - python:3.5:

--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -46,7 +46,7 @@ RAW_IDP_LIST = "\n".join(
 )
 def test_get_ecpcookie_path():
     if os.name == "nt":
-        path = r"%SYSTEMROOT%\Temp\ecpcookie.123"
+        path = r"C:\WINDOWS\Temp\ecpcookie.123"
     else:
         path = "/tmp/ecpcookie.u123"
     assert ciecplib_utils.get_ecpcookie_path() == Path(path)
@@ -58,7 +58,7 @@ def test_get_ecpcookie_path():
 )
 def test_get_x509_proxy_path():
     if os.name == "nt":
-        path = r"%SYSTEMROOT%\Temp\x509up_123"
+        path = r"C:\WINDOWS\Temp\x509up_123"
     else:
         path = "/tmp/x509up_u123"
     assert ciecplib_utils.get_x509_proxy_path() == Path(path)

--- a/ciecplib/utils.py
+++ b/ciecplib/utils.py
@@ -32,7 +32,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 def _tmpfile(prefix):
     if os.name == "nt":
-        tmpdir = r'%SYSTEMROOT%\Temp'
+        tmpdir = Path(os.environ["SYSTEMROOT"]) / "Temp"
         user = os.getlogin()
     else:
         tmpdir = "/tmp"


### PR DESCRIPTION
This PR fixes a bug getting the default X509 path on windows. For some reason I originally coded this up to only work in the old command prompt, so trying to use it on powershell fails without this patch.