### PR TITLE
Fix verbose print bug in ecp_get_cert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ aliases:
         command: |
           set -x;
           # install test requirements
-          python${PYTHON_VERSION} -m pip install "pip >=9.0.0"
+          python${PYTHON_VERSION} -m pip install --upgrade pip
           python${PYTHON_VERSION} -m pip install -r requirements-test.txt
           # run test suite
           mkdir -pv tests;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,11 @@ aliases:
           set -x;
           # install test requirements
           python${PYTHON_VERSION} -m pip install --upgrade pip
-          python${PYTHON_VERSION} -m pip install -r requirements-test.txt
+          python${PYTHON_VERSION} -m pip install \
+              --upgrade \
+              --upgrade-strategy only-if-needed \
+              -r requirements-test.txt \
+          ;
           # run test suite
           mkdir -pv tests;
           pushd tests;

--- a/ciecplib/tool/ecp_get_cert.py
+++ b/ciecplib/tool/ecp_get_cert.py
@@ -191,7 +191,7 @@ def main(args=None):
 
     # if asked to reuse, check that we can
     if args.reuse:
-        print("Validating existing certificate...", end=" ")
+        vprint("Validating existing certificate...", end=" ")
         args.reuse = can_reuse(args.file, proxy=args.proxy)
         if args.reuse:
             vprint("OK")


### PR DESCRIPTION
This PR fixes a bug in `ecp_get_cert` where a print command would always be emitted, even when not using `--verbose`.