### PR TITLE
Add missing debian requirement and run tests during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,12 +301,12 @@ jobs:
     environment:
       PYTHON_VERSION: "3.7"
 
-  debian:bullseye:3.8:
+  debian:bullseye:3.9:
     <<: *debian
     docker:
       - image: debian:bullseye
     environment:
-      PYTHON_VERSION: "3.8"
+      PYTHON_VERSION: "3.9"
 
   rhel:centos8:3.6:
     <<: *centos
@@ -373,7 +373,7 @@ workflows:
       - debian:buster:3.7:
           requires:
             - sdist
-      - debian:bullseye:3.8:
+      - debian:bullseye:3.9:
           requires:
             - sdist
       - python:3.5:

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -25,6 +25,8 @@ from http import client as http_client
 from unittest import mock
 from urllib.error import URLError
 
+from requests import RequestException
+
 import pytest
 
 from ... import __version__ as ciecplib_version
@@ -59,7 +61,7 @@ def test_list_idps_action(capsys):
     with pytest.raises(SystemExit):
         try:
             parser.parse_args(["--list-idps"])
-        except URLError as exc:
+        except (RequestException, URLError) as exc:
             pytest.skip(str(exc))
     stdout = capsys.readouterr()[0]
     assert "'Cardiff University'" in stdout

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 ciecplib (0.4.1-2) unstable; urgency=low
 
   * add missing requirement on python3-distutils
+  * run test suite during build
 
  -- Duncan Macleod <duncan.macleod@ligo.org>  Tue, 05 Jan 2021 11:03:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ciecplib (0.4.1-2) unstable; urgency=low
+
+  * add missing requirement on python3-distutils
+
+ -- Duncan Macleod <duncan.macleod@ligo.org>  Tue, 05 Jan 2021 11:03:00 +0000
+
 ciecplib (0.4.1-1) unstable; urgency=low
 
   * Update for 0.4.1 bug-fix release

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,10 @@ Build-Depends:
  python3-distutils,
  python3-m2crypto,
  python3-openssl,
+ python3-pytest,
  python3-requests,
  python3-requests-ecp,
+ python3-requests-mock,
  python3-setuptools,
 
 # -- python3-ciecplib ---------------------------------------------------------

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends:
  dh-python,
  python3-all,
  python3-argparse-manpage,
+ python3-distutils,
  python3-m2crypto,
  python3-openssl,
  python3-requests,
@@ -26,6 +27,7 @@ Architecture: all
 Depends:
  ${misc:Depends},
  ${python3:Depends},
+ python3-distutils,
  python3-m2crypto,
  python3-openssl,
  python3-requests,

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,9 @@
 
 include /usr/share/dpkg/pkg-info.mk
 
-export PYBUILD_DISABLE = test
+export PYBUILD_OPTION = --test-pytest
+export PYBUILD_DISABLE_python3.5 = test
+export PYBUILD_TEST_ARGS = --verbose -r s
 
 %:
 	dh $@ \


### PR DESCRIPTION
This PR adds a missing `Requires:` in the debian packaging, and updates the `rules` to run the test suite during the dpkg build.