### PR TITLE
Add common tests for entry points

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,11 @@ jobs:
       run: |
         conda install --quiet --yes --name test \
             --file requirements.txt \
-            --file requirements-test.txt \
+        ;
+        # we install the test requirements using pip because
+        # that file contains environment markers
+        python -m pip install
+            -r requirements-test.txt \
         ;
 
     - name: Install ciecplib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,15 +73,12 @@ jobs:
       run: |
         conda install --quiet --yes --name test \
             --file requirements.txt \
-        ;
-        # we install the test requirements using pip because
-        # that file contains environment markers
-        python -m pip install
-            -r requirements-test.txt \
+            pytest \
+            pytest-cov \
         ;
 
     - name: Install ciecplib
-      run: python -m pip install . --no-build-isolation -vv
+      run: python -m pip install .[tests] --no-build-isolation -vv
 
     - name: Package list
       run: conda list --name test

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -146,10 +146,12 @@ jobs:
           rm -fv ${DEB}
 
       - name: Install build dependencies
+        shell: bash -ex {0}
         run: |
           cd src
+          if [[ "${{ matrix.debian }}" == *backports ]]; then BACKPORTS="-t ${{ matrix.debian }}"; fi
           mk-build-deps \
-              --tool "apt-get -y -q -o Debug::pkgProblemResolver=yes --no-install-recommends" \
+              --tool "apt-get -y -q ${BACKPORTS} -o Debug::pkgProblemResolver=yes --no-install-recommends" \
               --install \
               --remove \
           ;

--- a/ciecplib/tool/tests/__init__.py
+++ b/ciecplib/tool/tests/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for ciecplib
+"""Tests for ciecplib.tool
 """
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/ciecplib/tool/tests/test_common.py
+++ b/ciecplib/tool/tests/test_common.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2019-2020)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Common testt for ciecplib entry points
+
+Inspired by the test_help module from ligo.skymap.tool.tests,
+thanks Leo!
+"""
+
+import subprocess
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:  # python < 3.7
+    import importlib_metadata
+
+import pytest
+
+from ... import (__version__, __name__)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+try:
+    ENTRY_POINTS = [
+        ep
+        for ep in importlib_metadata.distribution(__name__).entry_points
+        if ep.group == "console_scripts"
+    ]
+except importlib_metadata.PackageNotFoundError:
+    ENTRY_POINTS = []
+PARAMETRIZE_ENTRY_POINTS = pytest.mark.parametrize(
+    "ep", [
+        pytest.param(ep, id=ep.name)
+        for ep in ENTRY_POINTS
+    ],
+)
+
+
+def _test_entry_point(ep, args):
+    main = ep.load()
+    with pytest.raises(SystemExit) as exc:
+        main(args)
+    if exc.value.code != 0:
+        raise subprocess.CalledProcessError(exc.value.code, [ep.name, *args])
+
+
+@PARAMETRIZE_ENTRY_POINTS
+def test_help(ep):
+    return _test_entry_point(ep, ['--help'])
+
+
+@PARAMETRIZE_ENTRY_POINTS
+def test_version(capsys, ep):
+    _test_entry_point(ep, ['--version'])
+    out, err = capsys.readouterr()
+    assert out.strip() == __version__

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for :mod:`ciecplib.utils`
+"""Tests for :mod:`ciecplib.tool.utils`
 """
 
 import argparse

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
  python3-all,
  python3-argparse-manpage,
  python3-distutils,
+ python3-importlib-metadata | libpython3-stdlib,
  python3-m2crypto,
  python3-openssl,
  python3-pytest,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,0 @@
-importlib_metadata ; python_version < '3.7'
-pytest >= 3.9.0
-pytest-cov >= 2.6.1
-requests-mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+importlib_metadata ; python_version < '3.7'
 pytest >= 3.9.0
 pytest-cov >= 2.6.1
 requests-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ docs =
 	sphinx_rtd_theme
 	sphinx_tabs
 tests =
-	importlib_metadata ; python_version < '3.7'
+	importlib-metadata ; python_version < '3.8'
 	pytest >= 3.9.0
 	pytest-cov
 	requests-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,10 +38,6 @@ install_requires =
 	pyOpenSSL
 	requests
 	requests-ecp
-test_require =
-	pytest >= 3.9.0
-	pytest-cov
-	requests-mock
 
 [options.extras_require]
 docs =
@@ -50,6 +46,11 @@ docs =
 	sphinx_automodapi
 	sphinx_rtd_theme
 	sphinx_tabs
+tests =
+	importlib_metadata ; python_version < '3.7'
+	pytest >= 3.9.0
+	pytest-cov
+	requests-mock
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This PR adds a suite of common tests for all entry points, using `importlib.metadata` to discover and load the entry points in the first place.