### PR TITLE
Add stretch CI build using igwn/base container

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -57,11 +57,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        debian:
-          - buster-backports
-          - bullseye
+        include:
+          - debian: stretch
+            container: igwn/base:stretch-proposed
+          - debian: buster
+            container: debian:buster-backports
+          - debian: bullseye
+            container: debian:bullseye
     runs-on: ubuntu-latest
-    container: debian:${{ matrix.debian }}
+    container: ${{ matrix.container }}
     env:
       TARBALL: "ciecplib-*.tar.*"
     steps:
@@ -104,11 +108,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        debian:
-          - buster-backports
-          - bullseye
+        include:
+          - debian: stretch
+            container: igwn/base:stretch-proposed
+          - debian: buster
+            container: debian:buster-backports
+          - debian: bullseye
+            container: debian:bullseye
     runs-on: ubuntu-latest
-    container: debian:${{ matrix.debian }}
+    container: ${{ matrix.container }}
     env:
       DSC: "ciecplib_*.dsc"
     steps:
@@ -146,10 +154,12 @@ jobs:
           rm -fv ${DEB}
 
       - name: Install build dependencies
+        env:
+          DOCKER_CONTAINER: ${{ matrix.container }}
         shell: bash -ex {0}
         run: |
           cd src
-          if [[ "${{ matrix.debian }}" == *backports ]]; then BACKPORTS="-t ${{ matrix.debian }}"; fi
+          if [[ "${DOCKER_CONTAINER}" == *backports ]]; then BACKPORTS="-t ${DOCKER_CONTAINER##*:}"; fi
           mk-build-deps \
               --tool "apt-get -y -q ${BACKPORTS} -o Debug::pkgProblemResolver=yes --no-install-recommends" \
               --install \

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -181,6 +181,13 @@ jobs:
               dpkg --contents "${debf}"
           done
 
+      - name: Install new packages
+        run: |
+          dpkg --install *.deb || { \
+              apt-get -y -f install;
+              dpkg --install *.deb;
+          }
+
       - uses: actions/upload-artifact@v2
         with:
           name: deb-${{ matrix.debian }}
@@ -309,6 +316,9 @@ jobs:
               echo "Requires:"
               rpm -qp --requires "${rpmf}"
           done
+
+      - name: Install new packages
+        run: yum -y localinstall *.rpm
 
       - uses: actions/upload-artifact@v2
         with:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ciecplib (0.4.2-2) unstable; urgency=low
+
+  * Fix requirements for stretch
+
+ -- Duncan Macleod <duncan.macleod@ligo.org>  Fri, 19 Mar 2021 15:50:00 +0000
+
 ciecplib (0.4.2-1) unstable; urgency=low
 
   * Update for 0.4.2 bug-fix release

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends:
  dh-python,
  python3-all,
  python3-argparse-manpage,
- python3-distutils,
+ python3-distutils | libpython3-stdlib,
  python3-importlib-metadata | libpython3-stdlib,
  python3-m2crypto,
  python3-openssl,
@@ -30,7 +30,7 @@ Architecture: all
 Depends:
  ${misc:Depends},
  ${python3:Depends},
- python3-distutils,
+ python3-distutils | libpython3-stdlib,
  python3-m2crypto,
  python3-openssl,
  python3-requests,


### PR DESCRIPTION
This PR adds a Debian stretch CI build using the `igwn/base:stretch-proposed` container.