### PR TITLE
Add more packaging tests to CI

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -48,6 +48,45 @@ jobs:
           path: ciecplib*.whl
           if-no-files-found: error
 
+  # -- Pip ------------------
+
+  pip-install:
+    name: Pip install from ${{ matrix.artifact }}
+    needs:
+      - tarball
+    strategy:
+      matrix:
+        include:
+          - artifact: tarball
+            source: ciecplib*.tar.*
+          - artifact: wheel
+            source: ciecplib*.whl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install build requirements
+        run: |
+          sudo apt-get install -y -q -q \
+              libkrb5-dev \
+          ;
+          python -m pip install --upgrade \
+              pip \
+              setuptools \
+              wheel \
+          ;
+
+      - name: Install from ${{ matrix.artifact }}
+        run: python -m pip install ${{ matrix.source }} -v
+
   # -- Debian ---------------
 
   debian-source:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -85,7 +85,66 @@ jobs:
           ;
 
       - name: Install from ${{ matrix.artifact }}
-        run: python -m pip install ${{ matrix.source }} -v
+        run: python -m pip install ${{ matrix.source }}
+
+  # -- Conda ----------------
+
+  conda-install:
+    name: Conda build (fake)
+    needs:
+      - tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: tarball
+
+      - name: Cache conda packages
+        uses: actions/cache@v2
+        env:
+          # increment to reset cache
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: conda-build-fake-${{ env.CACHE_NUMBER }}
+          restore-keys: conda-build-fake-
+
+      - name: Configure conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test
+          channels: conda-forge
+          python-version: 3
+          # this is needed for caching to work properly:
+          use-only-tar-bz2: true
+
+      - name: Conda info
+        run: conda info --all
+
+      - name: Unpack tarball
+        run: |
+          mkdir src
+          tar -xf ciecplib-*.tar.* --strip-components=1
+
+      - name: Install dependencies
+        run: |
+          conda install --quiet --yes --name test \
+              pip \
+              setuptools \
+              --file requirements.txt \
+          ;
+
+      - name: Install ciecplib
+        env:
+          # make out build look like a conda-build build
+          PIP_NO_BUILD_ISOLATION: "False"
+          PIP_NO_DEPENDENCIES: "True"
+          PIP_IGNORE_INSTALLED: "True"
+          PIP_CACHE_DIR: "${{ github.workspace }}/pip_cache"
+          PIP_NO_INDEX: "True"
+        shell: bash -el {0}
+        run: python -m pip install . -vv
 
   # -- Debian ---------------
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Install requests-ecp
         env:
-          REQUESTS_ECP_VERSION: "0.2.1-1"
+          REQUESTS_ECP_VERSION: "0.2.2-1"
         shell: sh -ex {0}
         run: |
           apt-get -y -q -q update
@@ -365,7 +365,7 @@ jobs:
 
       - name: Install requests-ecp
         env:
-          REQUESTS_ECP_VERSION: "0.2.1-1"
+          REQUESTS_ECP_VERSION: "0.2.2-1"
         shell: sh -ex {0}
         run: |
           yum -y -q update

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -365,7 +365,7 @@ jobs:
 
       - name: Install requests-ecp
         env:
-          REQUESTS_ECP_VERSION: "0.2.2-1"
+          REQUESTS_ECP_VERSION: "0.2.1-1"
         shell: sh -ex {0}
         run: |
           yum -y -q update

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE README.md MANIFEST.in
+include requirements.txt
 include *.spec
 recursive-include debian *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ requires = [
     "setuptools>=30.3.0",
     "wheel",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:__legacy__"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+argparse-manpage
 M2Crypto
 pyOpenSSL
 requests
 requests-ecp
+setuptools


### PR DESCRIPTION
This PR adds `pip install`-style tests to the packaging CI workflow to make sure that the source distributions work properly. This is to try and detect early those sorts of problems seem in the conda-forge build for ciecplib-0.4.2 (conda-forge/ciecplib-feedstock#9).