### PR TITLE
Fix test environment conflicts

### DIFF
--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -57,6 +57,7 @@ def test_argument_parser(capsys):
 
 
 @mock.patch("ciecplib.tool.utils.find_principal", side_effect=RuntimeError)
+@mock.patch.dict("os.environ", clear=True)
 def test_argument_parser_kerberos_error(capsys):
     parser = tools_utils.ArgumentParser()
     with pytest.raises(SystemExit):
@@ -64,6 +65,7 @@ def test_argument_parser_kerberos_error(capsys):
 
 
 @mock.patch("ciecplib.tool.utils.find_principal", return_value="user@REALM")
+@mock.patch.dict("os.environ", clear=True)
 def test_argument_parser_kerberos_defaults(capsys):
     parser = tools_utils.ArgumentParser()
     args = parser.parse_args(["--kerberos"])


### PR DESCRIPTION
This PR adds some decorators to clear the environment for a test function, so that local environment variables (`ECP_IDP`) don't get in the way of the test suite.