### PR TITLE
Use conditional for requests-ecp version in CI for debian

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Install requests-ecp
         env:
-          REQUESTS_ECP_VERSION: "0.2.2-1"
+          REQUESTS_ECP_VERSION: "${{ matrix.debian == 'stretch' && '0.2.1-1' || '0.2.2-1' }}"
         shell: sh -ex {0}
         run: |
           apt-get -y -q -q update


### PR DESCRIPTION
It seems the IGWN stretch repo didn't get updated to 0.2.2, so we need a fancy(ish) conditional on the version number we install in CI.