### PR TITLE
Remove use of distutils

### DIFF
--- a/ciecplib/kerberos.py
+++ b/ciecplib/kerberos.py
@@ -21,22 +21,14 @@
 
 import re
 import subprocess
-from distutils.spawn import find_executable
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
-KLIST_EXE = find_executable("klist")
+KLIST_EXE = "klist"
 KLIST_PRINCIPAL_RE = re.compile(
     r"\nDefault principal: ([\w\.@]+)",
     re.M,
 )
-
-
-def _find_executable(name):
-    exe = find_executable(name)
-    if exe is None:
-        raise OSError("cannot find {0!r}".format(name))
-    return exe
 
 
 def has_credential(klist=KLIST_EXE):
@@ -55,7 +47,6 @@ def has_credential(klist=KLIST_EXE):
         otherwise (including klist failures)
     """
     # run klist to check credentials
-    klist = klist or _find_executable("klist")
     try:
         subprocess.check_output([klist, "-s"])
     except subprocess.CalledProcessError:
@@ -71,7 +62,6 @@ def find_principal(klist=KLIST_EXE):
     klist : `str`, optional
         path to the ``klist`` executable, defaults to searching ``$PATH``
     """
-    klist = klist or _find_executable("klist")
     out = subprocess.check_output([klist]).decode("utf-8")
     try:
         return KLIST_PRINCIPAL_RE.search(out).groups()[0]

--- a/ciecplib/tests/test_kerberos.py
+++ b/ciecplib/tests/test_kerberos.py
@@ -41,12 +41,12 @@ Valid starting       Expires              Service principal
 @mock.patch("subprocess.check_output")
 def test_has_credential(mock_output, side_effect, result):
     mock_output.side_effect = side_effect
-    assert ciecplib_kerberos.has_credential("klist") is result
+    assert ciecplib_kerberos.has_credential() is result
 
 
 @mock.patch("subprocess.check_output", return_value=KLIST_OUTPUT)
 def test_find_principal(_):
-    assert ciecplib_kerberos.find_principal("klist") == "test.user@REALM.ORG"
+    assert ciecplib_kerberos.find_principal() == "test.user@REALM.ORG"
 
 
 @mock.patch("subprocess.check_output", return_value=b"")

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Build-Depends:
  dh-python,
  python3-all,
  python3-argparse-manpage,
- python3-distutils | libpython3-stdlib (<< 3.7.0),
  python3-importlib-metadata | python3-minimal (<< 3.9.0),
  python3-m2crypto,
  python3-openssl,
@@ -30,7 +29,6 @@ Architecture: all
 Depends:
  ${misc:Depends},
  ${python3:Depends},
- python3-distutils | libpython3-stdlib (<< 3.7.0),
  python3-m2crypto,
  python3-openssl,
  python3-requests,


### PR DESCRIPTION
This PR removes usage of the `distutils` module, it is [deprecated](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated), and we don't need to resolve the executable up-front anyway.