### PR TITLE
Add support for passing arguments to klist in ciecplib.kerberos module

### DIFF
--- a/ciecplib/kerberos.py
+++ b/ciecplib/kerberos.py
@@ -31,30 +31,46 @@ KLIST_PRINCIPAL_RE = re.compile(
 )
 
 
-def has_credential(klist=KLIST_EXE):
+def has_credential(*args, klist=KLIST_EXE):
     """Run ``klist`` to determine whether a kerberos credential is available.
 
     Parameters
     ----------
+    *args : `str`, optional
+        extra arguments to pass to ``klist``, note that the ``-s`` option
+        is always passed to ``klist``
+
     klist : `str`, optional
-        path to the ``klist`` executable, defaults to searching ``$PATH``
+        path to the ``klist`` executable
 
     Returns
-    ----------
+    -------
     True
         if ``klist -s`` indicates a valid credential
     False
         otherwise (including klist failures)
+
+    Examples
+    --------
+    >>> has_credential()
+    False
+    >>> has_credential("mykrb5cc", klist="/opt/special/bin/klist")
+    True
+
+    See also
+    --------
+    klist(1)
+        for details of options accepted by ``klist``
     """
     # run klist to check credentials
     try:
-        subprocess.check_output([klist, "-s"])
+        subprocess.check_output([klist, "-s"] + list(args))
     except subprocess.CalledProcessError:
         return False
     return True
 
 
-def find_principal(klist=KLIST_EXE):
+def find_principal(*args, klist=KLIST_EXE):
     """Determine the default principal for an active kerberos credential
 
     Parameters
@@ -62,7 +78,7 @@ def find_principal(klist=KLIST_EXE):
     klist : `str`, optional
         path to the ``klist`` executable, defaults to searching ``$PATH``
     """
-    out = subprocess.check_output([klist]).decode("utf-8")
+    out = subprocess.check_output([klist] + list(args)).decode("utf-8")
     try:
         return KLIST_PRINCIPAL_RE.search(out).groups()[0]
     except (AttributeError, IndexError):  # failed to parse principal

--- a/ciecplib/tests/test_kerberos.py
+++ b/ciecplib/tests/test_kerberos.py
@@ -39,9 +39,10 @@ Valid starting       Expires              Service principal
     (CalledProcessError(1, "klist"), False),
 ])
 @mock.patch("subprocess.check_output")
-def test_has_credential(mock_output, side_effect, result):
-    mock_output.side_effect = side_effect
-    assert ciecplib_kerberos.has_credential() is result
+def test_has_credential(_check_output, side_effect, result):
+    _check_output.side_effect = side_effect
+    assert ciecplib_kerberos.has_credential("krb5ccname") is result
+    _check_output.assert_called_once_with(["klist", "-s", "krb5ccname"])
 
 
 @mock.patch("subprocess.check_output", return_value=KLIST_OUTPUT)
@@ -50,7 +51,8 @@ def test_find_principal(_):
 
 
 @mock.patch("subprocess.check_output", return_value=b"")
-def test_find_principal_error(_):
+def test_find_principal_error(_check_output):
     with pytest.raises(RuntimeError) as exc:
-        ciecplib_kerberos.find_principal("klist")
+        ciecplib_kerberos.find_principal("krb5ccname")
+    _check_output.assert_called_once_with(["klist", "krb5ccname"])
     assert str(exc.value) == "failed to parse principal from `klist` output"


### PR DESCRIPTION
This PR improves the utility of the `ciecplib.kerberos` module by enabling passing arguments to `klist`.