### PR TITLE
Improve preferred IdP match to work with hostnames

### DIFF
--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -112,8 +112,11 @@ def test_get_idp_url(requests_mock, value, krb, result):
 
 
 @pytest.mark.parametrize("inst", [
-    "Institution*",
-    "test",
+    # name too vague, multiple matches
+    "Institution",
+    # URL too vague, multiple matches
+    "login",
+    # no matches
     "something else",
 ])
 def test_get_idp_url_error(requests_mock, inst):

--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -37,6 +37,9 @@ INST_DICT = {
     "Institution A (Kerberos)":
         "https://login.insta.krb/idp-krb/profile/SAML2/SOAP/ECP",
     "Institution B": "https://login.instb.org/idp/profile/SAML2/SOAP/ECP",
+    "Institution C": "https://login.instc.org/idp/profile/SAML2/SOAP/ECP",
+    "Institution C (backup)":
+        "https://login2.instc.org/idp/profile/SAML2/SOAP/ECP",
 }
 INSTITUTIONS = [
     EcpIdP(
@@ -92,6 +95,10 @@ def test_get_idps(requests_mock):
     # valid ECP URL, just return it
     ("https://myidp.org/idp/profile/SAML2/SOAP/ECP", None,
      "https://myidp.org/idp/profile/SAML2/SOAP/ECP"),
+    # preferred match based on institution name
+    ("Institution C", None, INST_DICT["Institution C"]),
+    # preferred match based on URL
+    ("instc", None, INST_DICT["Institution C"]),
 ])
 def test_get_idp_url(requests_mock, value, krb, result):
     # only proxy idp-list-url if we need to

--- a/ciecplib/tests/test_utils.py
+++ b/ciecplib/tests/test_utils.py
@@ -33,10 +33,10 @@ EcpIdP = ciecplib_utils.EcpIdentityProvider
 
 # mock response from ECP IdP list
 INST_DICT = {
-    "Institution 1": "https://inst1.test/idp/profile/SAML2/SOAP/ECP",
-    "Institution 1 (Kerberos)":
-        "https://inst1.test.krb/idp-krb/profile/SAML2/SOAP/ECP",
-    "Institution 2": "https://inst2.test/idp/profile/SAML2/SOAP/ECP",
+    "Institution A": "https://login.insta.org/idp/profile/SAML2/SOAP/ECP",
+    "Institution A (Kerberos)":
+        "https://login.insta.krb/idp-krb/profile/SAML2/SOAP/ECP",
+    "Institution B": "https://login.instb.org/idp/profile/SAML2/SOAP/ECP",
 }
 INSTITUTIONS = [
     EcpIdP(
@@ -80,15 +80,18 @@ def test_get_idps(requests_mock):
 
 
 @pytest.mark.parametrize("value, krb, result", [
-    ("Institution 1", False, INST_DICT["Institution 1"]),
-    ("Institution 1 (Kerberos)", None,
-     INST_DICT["Institution 1 (Kerberos)"]),
-    ("Institution 1", True, INST_DICT["Institution 1 (Kerberos)"]),
-    ("inst1", False, INST_DICT["Institution 1"]),
-    ("inst1.test.krb", None, INST_DICT["Institution 1 (Kerberos)"]),
-    ("inst2", None, INST_DICT["Institution 2"]),
-    ("https://inst1.test/idp/profile/SAML2/SOAP/ECP", None,
-     INST_DICT["Institution 1"]),
+    # direct match for institution
+    ("Institution A", False, INST_DICT["Institution A"]),
+    ("Institution A (Kerberos)", None, INST_DICT["Institution A (Kerberos)"]),
+    # kerberos selection
+    ("Institution A", True, INST_DICT["Institution A (Kerberos)"]),
+    # partial match for URL
+    ("insta", False, INST_DICT["Institution A"]),
+    ("login.insta.krb", None, INST_DICT["Institution A (Kerberos)"]),
+    ("instb", None, INST_DICT["Institution B"]),
+    # valid ECP URL, just return it
+    ("https://myidp.org/idp/profile/SAML2/SOAP/ECP", None,
+     "https://myidp.org/idp/profile/SAML2/SOAP/ECP"),
 ])
 def test_get_idp_url(requests_mock, value, krb, result):
     # only proxy idp-list-url if we need to

--- a/ciecplib/utils.py
+++ b/ciecplib/utils.py
@@ -158,14 +158,16 @@ def _match_institution(value, institutions, kerberos=None):
 
     # try and match the institution name
     matches = _preferred_match(
-        _match(value, institutions, "name", kerberos=kerberos)
+        _match(value, institutions, "name", kerberos=kerberos),
     )
     if len(matches) == 1:
         return matches.pop()
 
     # otherwise match the IdP URL
     if _URL_REGEX.match(value):
-        umatches = _match(value, institutions, "url", kerberos=kerberos)
+        umatches = _preferred_match(
+            _match(value, institutions, "url", kerberos=kerberos),
+        )
         if len(umatches) == 1:
             return umatches.pop()
         matches = matches or umatches or []


### PR DESCRIPTION
This PR improves the preferred match logic internal to `ciecplib.utils.get_idp_url` so that it works also with domain names, e.g. so that `get_idp_url('ligo.org')` actually matches the `login.ligo.org` server first, and not `login2.ligo.org` (as documented).