### PR TITLE
Improve kerberos handling when creating a Session

### DIFF
--- a/ciecplib/kerberos.py
+++ b/ciecplib/kerberos.py
@@ -83,3 +83,31 @@ def find_principal(*args, klist=KLIST_EXE):
         return KLIST_PRINCIPAL_RE.search(out).groups()[0]
     except (AttributeError, IndexError):  # failed to parse principal
         raise RuntimeError("failed to parse principal from `klist` output")
+
+
+def realm(principal):
+    """Return the kerbeos realm name from a principal
+
+    Parameters
+    ----------
+    principal : `str`
+        the kerberos principal to parse
+
+    Returns
+    -------
+    realm : `str`
+        the realm name
+
+    Examples
+    --------
+    >>> realm('marie.curie@EXAMPLE.ORG')
+    'EXAMPLE.ORG'
+    """
+    try:
+        user, realm = principal.rsplit("@", 1)
+    except ValueError as exc:  # no "@" character
+        exc.args = (
+            f"invalid kerberos principal '{principal}'",
+        )
+        raise
+    return realm

--- a/ciecplib/requests.py
+++ b/ciecplib/requests.py
@@ -37,7 +37,7 @@ def _ecp_session(func):
                 idp=kwargs.pop("endpoint", DEFAULT_IDP),
                 username=kwargs.pop("username", None),
                 password=kwargs.pop("password", None),
-                kerberos=kwargs.pop("kerberos", False),
+                kerberos=kwargs.pop("kerberos", None),
                 cookiejar=kwargs.pop("cookiejar", None),
             )
         return func(*args, **kwargs)

--- a/ciecplib/sessions.py
+++ b/ciecplib/sessions.py
@@ -60,7 +60,7 @@ class Session(ECPSession):
 
         # open session with ECP authentication
         super().__init__(
-            idp=get_idp_url(idp),
+            idp=get_idp_url(idp) if idp else None,
             kerberos=kerberos,
             username=username,
             password=password,

--- a/ciecplib/tests/test_kerberos.py
+++ b/ciecplib/tests/test_kerberos.py
@@ -56,3 +56,13 @@ def test_find_principal_error(_check_output):
         ciecplib_kerberos.find_principal("krb5ccname")
     _check_output.assert_called_once_with(["klist", "krb5ccname"])
     assert str(exc.value) == "failed to parse principal from `klist` output"
+
+
+def test_realm():
+    assert ciecplib_kerberos.realm("marie.curie@EXAMPLE.ORG") == "EXAMPLE.ORG"
+
+
+def test_realm_error():
+    with pytest.raises(ValueError) as exc:
+        ciecplib_kerberos.realm("marie.curie")
+    assert str(exc.value) == "invalid kerberos principal 'marie.curie'"

--- a/ciecplib/tests/test_sessions.py
+++ b/ciecplib/tests/test_sessions.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2022)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suite for :mod:`cieclib.sessions`
+"""
+
+from unittest import mock
+
+import pytest
+
+from .. import sessions as ciecplib_sessions
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+class TestSession():
+    TEST_CLASS = ciecplib_sessions.Session
+
+    @mock.patch("ciecplib.sessions._get_default_idp", lambda: None)
+    @mock.patch("ciecplib.sessions.has_krb5_credential", lambda: False)
+    def test_init_error(self):
+        """Check that the right error is raised when a Session is created
+        with no IdP or kerberos credentials
+        """
+        with pytest.raises(ValueError) as exc:
+            self.TEST_CLASS()
+        assert str(exc.value).startswith("no Identity Provider")


### PR DESCRIPTION
This PR works around some issues for users who don't specify the endpoint when making a request, and don't have `ECP_IDP` set (which is the default for 'new' users). There are two things included here

- attempt to use a kerberos principal name to infer the IdP
- improve the error handling when the IdP is not given or discoverable

This (when combined with #84) should mean that the following results are given for LIGO users who don't have `ECP_IDP` configured:

1. no kerberos credential
 
    ```python
    >>> from ciecplib import get
    >>> print(get('https://ldas-jobs.ligo.caltech.edu/~duncan.macleod/hello.html').text)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/duncan/git/ciecplib/ciecplib/requests.py", line 36, in _wrapper
        kwargs['session'] = Session(
      File "/home/duncan/git/ciecplib/ciecplib/sessions.py", line 55, in __init__
        raise ValueError(
    ValueError: no Identity Provider (IdP) given, and no kerberos credential discovered, unable to dynamically determine IdP endpoint
    ```
2. active LIGO.ORG-real kerberos credential

    ```python
    >>> from ciecplib import get
    >>> print(get('https://ldas-jobs.ligo.caltech.edu/~duncan.macleod/hello.html').text)
    HELLO

    ```

cc @SeanDS 