### PR TITLE
ciecplib.sessions: support variadic keyword arguments in Session constructor

### DIFF
--- a/ciecplib/sessions.py
+++ b/ciecplib/sessions.py
@@ -65,7 +65,7 @@ class Session(ECPSession):
             kerberos=kerberos,
             username=username,
             password=password,
-            **kwargs
+            **kwargs,
         )
 
         # load cookies from existing jar or file

--- a/ciecplib/sessions.py
+++ b/ciecplib/sessions.py
@@ -45,7 +45,7 @@ class Session(ECPSession):
             username=None,
             password=None,
             cookiejar=None,
-            **kwargs
+            **kwargs,
     ):
 
         if kerberos is None:

--- a/ciecplib/sessions.py
+++ b/ciecplib/sessions.py
@@ -45,6 +45,7 @@ class Session(ECPSession):
             username=None,
             password=None,
             cookiejar=None,
+            **kwargs
     ):
 
         if kerberos is None:
@@ -64,6 +65,7 @@ class Session(ECPSession):
             kerberos=kerberos,
             username=username,
             password=password,
+            **kwargs
         )
 
         # load cookies from existing jar or file


### PR DESCRIPTION
This adds support for variadic keyword arguments in the `Session` constructor to facilitate usage in classes with multiple inheritance.