### PR TITLE
Use mamba for readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,15 +2,18 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
 
 conda:
   environment: docs/rtd-environment.yml
+
+sphinx:
+  configuration: docs/conf.py
 
 python:
   install:

--- a/docs/rtd-environment.yml
+++ b/docs/rtd-environment.yml
@@ -2,16 +2,18 @@ name: ciecplib
 channels:
   - conda-forge
 dependencies:
-  - m2crypto
-  - pip
-  - pyopenssl
   - python>=3
+  # build
+  - pip
+  - setuptools
+  # install
+  - m2crypto
+  - pyopenssl
   - requests
   - requests-ecp
-  - setuptools
+  # docs
   - sphinx
   - sphinx-argparse
   - sphinx-automodapi
   - sphinx_rtd_theme
-  - pip:
-    - sphinx_tabs
+  - sphinx-tabs


### PR DESCRIPTION
This PR updates the `.readthedocs.yml` configuration file so that `mamba` is used to build the environment - this greatly reduces the overhead of the build. See https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba for an explanation of the changes.