### PR TITLE
New ciecplib.logging module to handle debugging

### DIFF
--- a/ciecplib/logging.py
+++ b/ciecplib/logging.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2022)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Logging utilities for CIECPLib
+"""
+
+import logging
+from http.client import HTTPConnection
+
+logging.basicConfig()
+ROOT_LOGGER = logging.getLogger()
+URLLIB3_LOGGER = logging.getLogger("requests.packages.urllib3")
+DEFAULT_LEVEL = URLLIB3_LOGGER.level
+
+
+def init_logging(level=logging.DEBUG):
+    """Enable logging in requests.
+
+    This function is taken from
+    https://requests.readthedocs.io/en/v2.9.1/api/#api-changes
+    """
+    # set levels for loggers (also validates the input)
+    ROOT_LOGGER.setLevel(level)
+    URLLIB3_LOGGER.setLevel(level)
+    # set debug logging for connections
+    debug = ROOT_LOGGER.level == logging.DEBUG
+    HTTPConnection.debuglevel = int(debug)
+    URLLIB3_LOGGER.propagate = debug
+    return URLLIB3_LOGGER
+
+
+def reset_logging():
+    return init_logging(level=DEFAULT_LEVEL)

--- a/ciecplib/requests.py
+++ b/ciecplib/requests.py
@@ -39,6 +39,7 @@ def _ecp_session(func):
                 password=kwargs.pop("password", None),
                 kerberos=kwargs.pop("kerberos", None),
                 cookiejar=kwargs.pop("cookiejar", None),
+                debug=kwargs.get("debug", False),
             )
         return func(*args, **kwargs)
     return _wrapper

--- a/ciecplib/sessions.py
+++ b/ciecplib/sessions.py
@@ -28,6 +28,10 @@ from .kerberos import (
     find_principal as find_krb5_principal,
     realm as krb5_realm,
 )
+from .logging import (
+    init_logging,
+    reset_logging,
+)
 from .utils import get_idp_url
 
 __all__ = [
@@ -45,6 +49,7 @@ class Session(ECPSession):
             username=None,
             password=None,
             cookiejar=None,
+            debug=False,
             **kwargs,
     ):
 
@@ -72,3 +77,12 @@ class Session(ECPSession):
         self.cookies = ECPCookieJar()
         if cookiejar:
             self.cookies.update(cookiejar)
+
+        # configure debugging
+        self.debug = debug
+        if self.debug:
+            init_logging(level="DEBUG")
+
+    def close(self):
+        reset_logging()
+        return super().close()

--- a/ciecplib/tool/ecp_curl.py
+++ b/ciecplib/tool/ecp_curl.py
@@ -34,7 +34,6 @@ from ..sessions import Session
 from ..utils import DEFAULT_COOKIE_FILE
 from .utils import (
     ArgumentParser,
-    init_logging,
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -90,8 +89,6 @@ def create_parser():
 def main(args=None):
     parser = create_parser()
     args = parser.parse_args(args=args)
-    if args.debug:
-        init_logging()
     cookiejar = load_cookiejar(
         args.cookiefile,
         strict=False,

--- a/ciecplib/tool/ecp_get_cert.py
+++ b/ciecplib/tool/ecp_get_cert.py
@@ -35,7 +35,6 @@ from ..utils import DEFAULT_X509_USER_FILE
 from .utils import (
     ArgumentParser,
     destroy_file,
-    init_logging,
 )
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -185,9 +184,6 @@ def main(args=None):
         """
         if args.verbose:
             print(*pargs, **kwargs)
-
-    if args.debug:
-        init_logging()
 
     # if asked to destroy, just do that
     if args.destroy:

--- a/ciecplib/tool/ecp_get_cookie.py
+++ b/ciecplib/tool/ecp_get_cookie.py
@@ -52,7 +52,6 @@ from ..utils import DEFAULT_COOKIE_FILE
 from .utils import (
     ArgumentParser,
     destroy_file,
-    init_logging,
 )
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -144,9 +143,6 @@ def main(args=None):
         """
         if args.verbose:
             print(*pargs, **kwargs)
-
-    if args.debug:
-        init_logging()
 
     # if asked to destroy, just do that
     if args.destroy:

--- a/ciecplib/tool/tests/test_utils.py
+++ b/ciecplib/tool/tests/test_utils.py
@@ -20,8 +20,6 @@
 """
 
 import argparse
-import logging
-from http import client as http_client
 from unittest import mock
 
 import pytest
@@ -84,12 +82,3 @@ def test_list_idps_action(_, capsys):
         parser.parse_args(["--list-idps"])
     stdout = capsys.readouterr()[0]
     assert "'Cardiff University'" in stdout
-
-
-@mock.patch.dict(logging.Logger.manager.loggerDict)
-@mock.patch("{}.HTTPConnection.debuglevel".format(http_client.__name__))
-def test_init_logging(_):
-    log = tools_utils.init_logging(logging.FATAL)
-    assert http_client.HTTPConnection.debuglevel == 1
-    assert log is logging.Logger.manager.loggerDict["urllib3"]
-    assert log.level == logging.FATAL

--- a/ciecplib/tool/utils.py
+++ b/ciecplib/tool/utils.py
@@ -20,11 +20,9 @@
 """
 
 import argparse
-import logging
 import os
 import sys
 from functools import wraps
-from http.client import HTTPConnection
 from operator import attrgetter
 
 from .. import __version__
@@ -259,21 +257,6 @@ def reuse_cookies(cookiejar, url, verbose=False):
     elif verbose:
         print("cannot reuse, need new cookies")
     return cookiejar, reuse
-
-
-def init_logging(level=logging.DEBUG):
-    """Enable logging in requests.
-
-    This function is taken from
-    https://requests.readthedocs.io/en/v2.9.1/api/#api-changes
-    """
-    HTTPConnection.debuglevel = 1
-    logging.basicConfig()
-    logging.getLogger().setLevel(level)
-    requests_log = logging.getLogger("urllib3")
-    requests_log.setLevel(level)
-    requests_log.propagate = True
-    return requests_log
 
 
 def destroy_file(path, desc=None, verbose=False):

--- a/ciecplib/ui.py
+++ b/ciecplib/ui.py
@@ -69,6 +69,9 @@ def get_cookie(
     session : `requests.Session`, optional
         an active `requests.Session` to use with the query
 
+    return_all : `bool`, optional
+        return all cookies from the authentication request
+
     Returns
     -------
     cookie : `http.cookiejar.Cookie`


### PR DESCRIPTION
This PR adds a new `ciecplib.logging` module to handle setting/unsetting debug logging, with the logic migrated from `ciecplib.tools.utils`. This allows configuring debug logging at the `Session` level which makes it easier to use.