### PR TITLE
Fix rpmlint CI job

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -487,7 +487,7 @@ jobs:
   lint-rhel:
     name: Lint CentOS packages
     runs-on: ubuntu-latest
-    container: centos:8
+    container: rockylinux:8
     needs:
       - rhel-binary
     steps:


### PR DESCRIPTION
This PR fixes the failures in the `rpmlint` job in the packaging GHA workflow; `centos:8` is dead, long live `rockylinux:8`!