### PR TITLE
Update CI to use pip2conda and mamba

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,8 @@ jobs:
       run: python -m coverage report --show-missing
 
     - name: Publish coverage to Codecov
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2
       with:
-        files: coverage.xml
         flags: ${{ runner.os }},python${{ matrix.python-version }}
 
     - name: Upload test results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,15 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - main
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   conda:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,17 +62,18 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: test
-        channels: conda-forge
+        miniforge-variant: Mambaforge
         python-version: ${{ matrix.python-version }}
+        use-mamba: true
         # this is needed for caching to work properly:
         use-only-tar-bz2: true
 
     - name: Conda info
-      run: conda info --all
+      run: mamba info --all
 
     - name: Install dependencies
       run: |
-        conda install --quiet --yes --name test \
+        mamba install --quiet --yes --name test \
             --file requirements.txt \
             pytest \
             pytest-cov \
@@ -82,10 +83,10 @@ jobs:
       run: python -m pip install .[tests] --no-build-isolation -vv
 
     - name: Package list
-      run: conda list --name test
+      run: mamba list --name test
 
     - name: Run test suite
-      run: python -m pytest -ra --color yes --cov ciecplib --pyargs ciecplib --cov-report=xml --junitxml=pytest.xml
+      run: python -m pytest -ra --verbose --cov ciecplib --pyargs ciecplib --cov-report=xml --junitxml=pytest.xml
 
     - name: Coverage report
       run: python -m coverage report --show-missing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,24 @@ jobs:
     - name: Conda info
       run: mamba info --all
 
-    - name: Install dependencies
+    - name: Install dependencies with conda
       run: |
+        # parse requirements to install as much as possible with conda
+        mamba install --name base pip2conda
+        ${CONDA_PYTHON_EXE} -m pip2conda \
+            --all \
+            --output environment.txt \
+            --python-version ${{ matrix.python-version }}
+        echo "-----------------"
+        cat environment.txt
+        echo "-----------------"
+        # install the requested packages, ensuring that all of the packages
+        # we use explicitly are installed as well
         mamba install --quiet --yes --name test \
-            --file requirements.txt \
+            pip \
             pytest \
             pytest-cov \
-        ;
+            --file environment.txt
 
     - name: Install ciecplib
       run: python -m pip install .[tests] --no-build-isolation -vv

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,15 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - main
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   flake8:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -11,9 +11,15 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - main
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tarball:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -100,6 +100,9 @@ jobs:
     needs:
       - tarball
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Download tarball
         uses: actions/download-artifact@v2
@@ -120,8 +123,9 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test
-          channels: conda-forge
+          miniforge-variant: Mambaforge
           python-version: 3
+          use-mamba: true
           # this is needed for caching to work properly:
           use-only-tar-bz2: true
 
@@ -134,11 +138,19 @@ jobs:
           tar -xf ciecplib-*.tar.* --strip-components=1
 
       - name: Install dependencies
+        shell: bash -el {0}
         run: |
-          conda install --quiet --yes --name test \
+          mamba install --name base pip2conda
+          ${CONDA_PYTHON_EXE} -m pip2conda \
+              --output environment.txt \
+          ;
+          echo "-----------------"
+          cat environment.txt
+          echo "-----------------"
+          mamba install --quiet --yes --name test \
               pip \
-              setuptools \
-              --file requirements.txt \
+              wheel \
+              --file environment.txt \
           ;
 
       - name: Install ciecplib
@@ -149,8 +161,13 @@ jobs:
           PIP_IGNORE_INSTALLED: "True"
           PIP_CACHE_DIR: "${{ github.workspace }}/pip_cache"
           PIP_NO_INDEX: "True"
-        shell: bash -el {0}
         run: python -m pip install . -vv
+
+      - name: Package list
+        run: mamba list --name test
+
+      - name: Check the pip install
+        run: python -m pip check
 
   # -- Debian ---------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-argparse-manpage
-M2Crypto
-pyOpenSSL
-requests
-requests-ecp
-setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,9 @@ install_requires =
 docs =
 	sphinx
 	sphinx-argparse
-	sphinx_automodapi
+	sphinx-automodapi
 	sphinx_rtd_theme
-	sphinx_tabs
+	sphinx-tabs
 manpages =
 	argparse-manpage
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ docs =
 	sphinx_automodapi
 	sphinx_rtd_theme
 	sphinx_tabs
+manpages =
+	argparse-manpage
 tests =
 	importlib-metadata ; python_version < '3.8'
 	pytest >= 3.9.0


### PR DESCRIPTION
This PR updates the build.yml GHA workflow to use [`pip2conda`](https://pip2conda.readthedocs.io/) to parse `setup.cfg` into packages that can be installed by mamba.

This allows us to mamba install everything, which is nice, and removes the duplication of truth that was the `requirements.txt` file - now every development dependency should be stated in `[options.extras_require]` in the `setup.cfg` file.