### PR TITLE
Save all cookies with ecp-get-cookie

### DIFF
--- a/ciecplib/ui.py
+++ b/ciecplib/ui.py
@@ -79,6 +79,10 @@ def get_cookie(
             url=url,
         )
 
+        # make the original request, it may introduce more cookies
+        resp = sess.get(url=url)
+        resp.raise_for_status()
+
         # extract the shibsession cookie for the SP:
         #   we do this by searching for all cookies associated with
         #   the relevant SP domain, and picking the most recent one


### PR DESCRIPTION
This PR updates `ecp-get-cookie` to save _all_ returned cookies, not just the `_shibsession_*` cookie. This should enable a more full session experience, especially when authenticating against endpoints such as gitlab auth callbacks.