### PR TITLE
Migrate tool configuration out of setup.cfg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,22 @@
+; vim: set ft=dosini :
+
+[flake8]
+select =
+	# pycodestyle errors
+	E,
+	# pyflakes
+	F,
+	# pycodestyle warnings
+	W,
+ignore =
+	# line break before binary operator, use W504
+	W503,
+exclude =
+	__pycache__,
+	.eggs/,
+	.git/,
+	build/,
+	docs/,
+per-file-ignores =
+	# unused import in __init__
+	__init__.py:F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,14 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta:__legacy__"
+
+# -- tools
+
+[tool.coverage.report]
+precision = 1
+
+[tool.coverage.run]
+source = [ "ciecplib" ]
+
+[tool.pytest.ini_options]
+addopts = "-r s"

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,27 +68,3 @@ manpages =
 	man/ecp-get-cert.1:function=create_parser:module=ciecplib.tool.ecp_get_cert
 	man/ecp-get-cookie.1:function=create_parser:module=ciecplib.tool.ecp_get_cookie
 
-; -- tools
-
-[coverage:run]
-source = ciecplib
-
-[flake8]
-select =
-	C90,
-	E,
-	F,
-	W,
-ignore =
-	W503,
-exclude =
-	__pycache__,
-	.eggs/,
-	.git/,
-	build/,
-	docs/,
-per-file-ignores =
-	__init__.py:F401
-
-[tool:pytest]
-addopts = -r s


### PR DESCRIPTION
This PR migrates the configuration for helper tools (e.g. flake8) out of `setup.cfg` and into `pyproject.toml` or their own file, this is probably more future-proof.