### PR TITLE
Improve requests wrappers

### DIFF
--- a/ciecplib/__init__.py
+++ b/ciecplib/__init__.py
@@ -22,7 +22,8 @@
 # request the contents of a URL
 from .requests import (
     get,
-    request,
+    head,
+    post,
 )
 
 # generate session handling

--- a/ciecplib/requests.py
+++ b/ciecplib/requests.py
@@ -123,8 +123,14 @@ get = _session_func_factory(
     """
 )
 
-request = _session_func_factory(
-    "request",
-    """Request a URL using ECP authentication.
+head = _session_func_factory(
+    "head",
+    """Send a HEAD request using ECP authentication.
+    """
+)
+
+post = _session_func_factory(
+    "post",
+    """Send a POST request using ECP authentication.
     """
 )

--- a/ciecplib/tests/test_requests.py
+++ b/ciecplib/tests/test_requests.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2022)
+#
+# This file is part of ciecplib.
+#
+# ciecplib is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ciecplib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ciecplib.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`ciecplib.requests`
+"""
+
+from .. import requests as ciecplib_requests
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def test_get(requests_mock):
+    requests_mock.get("https://test.example.com", content=b"HELLO")
+    assert ciecplib_requests.get(
+        "https://test.example.com",
+        endpoint="https://test.example.com/SOAP/ECP",
+    ).text == "HELLO"


### PR DESCRIPTION
This PR updates the requests wrapper module (`ciecplib.requests`), removing the (broken) `request()` wrapper, and replacing with `head()` and `post()` wrappers.