### PR TITLE
Catch FileNotFoundError in kerberos.has_credential

### DIFF
--- a/ciecplib/kerberos.py
+++ b/ciecplib/kerberos.py
@@ -65,7 +65,10 @@ def has_credential(*args, klist=KLIST_EXE):
     # run klist to check credentials
     try:
         subprocess.check_output([klist, "-s"] + list(args))
-    except subprocess.CalledProcessError:
+    except (
+        subprocess.CalledProcessError,   # klist failed
+        FileNotFoundError,  # klist not available
+    ):
         return False
     return True
 

--- a/ciecplib/tests/test_kerberos.py
+++ b/ciecplib/tests/test_kerberos.py
@@ -36,7 +36,8 @@ Valid starting       Expires              Service principal
 
 @pytest.mark.parametrize("side_effect, result", [
     (None, True),
-    (CalledProcessError(1, "klist"), False),
+    (CalledProcessError(1, "klist"), False),  # klist failed
+    (FileNotFoundError("no klist"), False),  # klist not found
 ])
 @mock.patch("subprocess.check_output")
 def test_has_credential(_check_output, side_effect, result):


### PR DESCRIPTION
This PR updates `ciecplib.kerberos.has_credential()` to catch the case where `klist` isn't found on the system at all and return `False`. It might be worth adding a new return of `None` ('credential status unknown') in the future to evaluate as 'falsy' but be distinguishable from an actual `False` ('credential known to be not present').