### PR TITLE
Handle optional requests-ecp kerberos auth

### DIFF
--- a/ciecplib/kerberos.py
+++ b/ciecplib/kerberos.py
@@ -57,11 +57,28 @@ def has_credential(*args, klist=KLIST_EXE):
     >>> has_credential("mykrb5cc", klist="/opt/special/bin/klist")
     True
 
+    Notes
+    -----
+    This function will always return `False` if the requests-gssapi
+    Kerberos Auth plugin required by requests-ecp is not found.
+
     See also
     --------
     klist(1)
         for details of options accepted by ``klist``
     """
+    try:
+        from requests_ecp.auth import _import_kerberos_auth
+    except ImportError:
+        # probably requests-ecp < 0.3.0, which always supports kerberos
+        pass
+    else:
+        try:
+            _import_kerberos_auth()
+        except ImportError:
+            # requests-ecp doesn't support Kerberos, so we can't
+            return False
+
     # run klist to check credentials
     try:
         subprocess.check_output([klist, "-s"] + list(args))

--- a/ciecplib/tests/test_kerberos.py
+++ b/ciecplib/tests/test_kerberos.py
@@ -40,6 +40,7 @@ Valid starting       Expires              Service principal
     (FileNotFoundError("no klist"), False),  # klist not found
 ])
 @mock.patch("subprocess.check_output")
+@mock.patch.dict("sys.modules", {"requests_ecp.auth": None})
 def test_has_credential(_check_output, side_effect, result):
     _check_output.side_effect = side_effect
     assert ciecplib_kerberos.has_credential("krb5ccname") is result

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,24 @@ Installation
 
       Supported python versions: 3.5+.
 
+      .. admonition:: Default ``pip install`` doesn't include Kerberos Auth support
+
+          By default ``pip install ciecplib`` does not bundle
+          Kerberos auth support that is optional as of requests-ecp 0.3.0.
+
+          The ``ciecplib[kerberos]`` extra can be used to automatically
+          install ``requests-ecp[kerberos]``:
+
+          .. code-block:: shell
+
+              python -m pip install ciecplib[kerberos]
+
+          This does not ensure that a working version of the underlying GSSAPI
+          is installed (e.g, via MIT Kerberos).
+          If you need Kerberos auth, and need to install GSSAPI itself on your
+          system, it is recommended that you
+          **use Conda to install `ciecplib`**.
+
    .. tab:: Conda
 
       .. code-block:: bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ docs =
 	sphinx-automodapi
 	sphinx_rtd_theme
 	sphinx-tabs
+kerberos =
+	requests-ecp[kerberos]
 manpages =
 	argparse-manpage
 tests =


### PR DESCRIPTION
This PR adds extra error handling to accommodate that as of requests-ecp 0.3.0 the Kerberos auth is now optional.