### PR TITLE
Fix signing X.509 proxies

### DIFF
--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -429,7 +429,7 @@ def generate_proxy(cert, key, minhours=168, limited=False, bits=2048):
         extensions=extensions,
     ).add_extension(proxyinfoext, critical=True)
     proxy = builder.sign(
-        private_key=proxy_private_key,
+        private_key=key,
         algorithm=hashes.SHA256(),
         backend=default_backend(),
     )


### PR DESCRIPTION
This PR fixes an issue seen with X.509 proxy certificates that were being rejected by services. They were being signed with the wrong RSA key...

cc @astroclark @bbockelm