### PR TITLE
Use python-gssapi for Kerberos GSSAPI interactions

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -261,6 +261,11 @@ jobs:
         with:
           name: dsc-${{ matrix.debian }}
 
+      - name: Enable backports
+        if: matrix.debian == 'Buster'
+        run: |
+          echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
+
       - name: Configure apt
         run: |
           apt-get -y -q -q update

--- a/ciecplib.spec
+++ b/ciecplib.spec
@@ -66,6 +66,10 @@ Requires: python%{python3_pkgversion}-pyOpenSSL >= 17.1.0
 Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-requests-ecp
 Conflicts: ciecp-utils < 0.4.3-1
+%if 0%{?fedora} >= 36 || 0%{?rhel} >= 8
+Recommends: python%{python3_pkgversion}-gssapi
+Recommends: python%{python3_pkgversion}-requests-gssapi
+%endif
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 %description -n python%{python3_pkgversion}-%{srcname}
 The Python %{python3_version} client for SAML ECP authentication.

--- a/debian/control
+++ b/debian/control
@@ -13,11 +13,13 @@ Build-Depends:
  python3-all,
  python3-argparse-manpage,
  python3-cryptography,
+ python3-gssapi,
  python3-openssl (>=17.1.0),
  python3-importlib-metadata | python3-minimal (<< 3.9.0),
  python3-pytest,
  python3-requests,
  python3-requests-ecp,
+ python3-requests-kerberos,
  python3-requests-mock,
  python3-setuptools (>= 30.3.0),
 
@@ -33,6 +35,9 @@ Depends:
  python3-openssl (>=17.1.0),
  python3-requests,
  python3-requests-ecp,
+Recommends:
+ python3-gssapi,
+ python3-requests-kerberos,
 Description: Python client for SAML/ECP authentication and HTTP requests
  CIECPLib provides Python-based utilities for SAML/ECP authentication
  and HTTP requests.

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends:
  python3-cryptography,
  python3-gssapi,
  python3-openssl (>=17.1.0),
- python3-importlib-metadata | python3-minimal (<< 3.9.0),
+ python3-importlib-metadata | python3-minimal (>= 3.8.0),
  python3-pytest,
  python3-requests,
  python3-requests-ecp,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,7 @@ default_role = 'obj'
 # Intersphinx directory
 intersphinx_mapping = {
     'cryptography': ('https://cryptography.io/en/stable', None),
+    'gssapi': ('https://pythongssapi.github.io/python-gssapi/', None),
     'python': ('https://docs.python.org/3/', None),
     'requests': ('https://requests.readthedocs.io/en/stable/', None),
     'requests_ecp': ('https://requests-ecp.readthedocs.io/en/stable/', None),

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ docs =
 	sphinx_rtd_theme
 	sphinx-tabs
 kerberos =
+	gssapi
 	requests-ecp[kerberos]
 manpages =
 	argparse-manpage


### PR DESCRIPTION
This PR updates the `ciecplib.kerberos` module to use `python-gssapi` for Kerberos interactions, instead of `subprocess` and `kinit/klist`.