### PR TITLE
Don't test pip install on Python 3.6

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -68,7 +68,6 @@ jobs:
           - Ubuntu
           - Windows
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
This PR removes the `pip install` test based on Python 3.6, that version is now out-of-support.