### PR TITLE
Add BuildRequires: python3-devel to spec file

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -531,12 +531,12 @@ jobs:
           # print contents of packages
           for rpmf in *.rpm; do
               echo "===== ${rpmf}"
-              rpm -qlp "${rpmf}"
-              echo "Files:"
-              rpm -qip "${rpmf}"
-              echo "Provides:"
+              rpm -qp --info "${rpmf}"
+              echo "-- Files:"
+              rpm -qp --list "${rpmf}"
+              echo "-- Provides:"
               rpm -qp --provides "${rpmf}"
-              echo "Requires:"
+              echo "-- Requires:"
               rpm -qp --requires "${rpmf}"
           done
 

--- a/ciecplib.spec
+++ b/ciecplib.spec
@@ -26,7 +26,7 @@ BuildRequires: python-rpm-macros
 BuildRequires: python3-rpm-macros
 
 # build
-BuildRequires: python3 >= 3.6.0
+BuildRequires: python3-devel >= 3.6.0
 BuildRequires: python%{python3_pkgversion}-setuptools >= 30.3.0
 BuildRequires: python%{python3_pkgversion}-wheel
 


### PR DESCRIPTION
This PR adds `BuildRequires: python3-devel` to the RPM spec file, as required to properly populate `Provides: python3dist(ciecplib)`.