### PR TITLE
Specify kerberos=False for testing get()

### DIFF
--- a/ciecplib/tests/test_requests.py
+++ b/ciecplib/tests/test_requests.py
@@ -29,4 +29,5 @@ def test_get(requests_mock):
     assert ciecplib_requests.get(
         "https://test.example.com",
         endpoint="https://test.example.com/SOAP/ECP",
+        kerberos=False,
     ).text == "HELLO"


### PR DESCRIPTION
This PR patches a test function to specify `kerberos=False` so that a local (expired) Kerberos credential doesn't interfere with the test (which isn't testing Kerberos integration).