### PR TITLE
Replace assert statement with exception

### DIFF
--- a/ciecplib/tool/ecp_cert_info.py
+++ b/ciecplib/tool/ecp_cert_info.py
@@ -203,9 +203,9 @@ def main(args=None):
         stream=sys.stdout,
     )
 
-    # assert --valid if given
-    if args.valid:
-        assert isvalid, (
+    # check credential validity if given
+    if args.valid and not isvalid:
+        raise ValueError(
             f"timeleft ({remaining}) is less than required ({valid})"
         )
 

--- a/ciecplib/tool/tests/test_ecp_cert_info.py
+++ b/ciecplib/tool/tests/test_ecp_cert_info.py
@@ -39,7 +39,7 @@ def test_valid():
     """Check that the --valid option for ecp-cert-info works
     """
     ecp_cert_info.main(["--valid", "1:0"])
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ecp_cert_info.main(["--valid", "1:0"])
 
 


### PR DESCRIPTION
This PR addresses an issue highlighted by bandit by replacing use of an `assert` statement with a real exception. `assert` statements are optimised out of compiled code, see <https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement>.