### PR TITLE
Replace usage of datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/ciecplib/conftest.py
+++ b/ciecplib/conftest.py
@@ -19,10 +19,7 @@
 """Common fixtures for ciecplib tests
 """
 
-from datetime import (
-    datetime,
-    timedelta,
-)
+import datetime
 
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.backends import default_backend
@@ -59,14 +56,14 @@ def x509(public_key, private_key):
             (crypto_x509.NameOID.ORGANIZATIONAL_UNIT_NAME, "Gravity"),
         )
     ])
-    now = datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     return crypto_x509.CertificateBuilder(
         issuer_name=name,
         subject_name=name,
         public_key=public_key,
         serial_number=1000,
         not_valid_before=now,
-        not_valid_after=now + timedelta(seconds=86400),
+        not_valid_after=now + datetime.timedelta(seconds=86400),
     ).sign(private_key, hashes.SHA256(), backend=default_backend())
 
 

--- a/ciecplib/x509.py
+++ b/ciecplib/x509.py
@@ -401,16 +401,15 @@ def generate_proxy(cert, key, minhours=168, limited=False, bits=2048):
         )
 
     # build self-signed proxy certificate
+    expiry = cert.not_valid_after.astimezone(datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
     builder = crypto_x509.CertificateBuilder(
         issuer_name=cert.subject,
         subject_name=proxy_subject,
         public_key=proxy_public_key,
         serial_number=serial,
         not_valid_before=cert.not_valid_before,
-        not_valid_after=min(
-            datetime.datetime.utcnow() + datetime.timedelta(hours=minhours),
-            cert.not_valid_after,
-        ),
+        not_valid_after=min(now + datetime.timedelta(hours=minhours), expiry),
         extensions=extensions,
     ).add_extension(proxyinfoext, critical=True)
     proxy = builder.sign(


### PR DESCRIPTION
This PR replaces all usage of `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.UTC)`. The former is [deprecated](https://docs.python.org/3/whatsnew/3.12.html#deprecated) as of Python 3.12.