### PR TITLE
Add build.os to readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,10 +2,13 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3"
+
 sphinx:
   configuration: docs/conf.py
 


### PR DESCRIPTION
This PR fixes the readthedocs build by adding a `build` section to the RTD configuration.